### PR TITLE
I added the tuple unpacking ability.

### DIFF
--- a/ometa/_generated/parsley.py
+++ b/ometa/_generated/parsley.py
@@ -307,49 +307,49 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self._trace("'n'", (646, 649), self.input.position)
                 _G_exactly_100, lastError = self.exactly('n')
                 self.considerError(lastError, None)
-                _G_python_101, lastError = "\n", None
+                _G_python_101, lastError = ("\n"), None
                 self.considerError(lastError, None)
                 return (_G_python_101, self.currentError)
             def _G_or_102():
                 self._trace("'r'", (680, 683), self.input.position)
                 _G_exactly_103, lastError = self.exactly('r')
                 self.considerError(lastError, None)
-                _G_python_104, lastError = "\r", None
+                _G_python_104, lastError = ("\r"), None
                 self.considerError(lastError, None)
                 return (_G_python_104, self.currentError)
             def _G_or_105():
                 self._trace("'t'", (714, 717), self.input.position)
                 _G_exactly_106, lastError = self.exactly('t')
                 self.considerError(lastError, None)
-                _G_python_107, lastError = "\t", None
+                _G_python_107, lastError = ("\t"), None
                 self.considerError(lastError, None)
                 return (_G_python_107, self.currentError)
             def _G_or_108():
                 self._trace("'b'", (748, 751), self.input.position)
                 _G_exactly_109, lastError = self.exactly('b')
                 self.considerError(lastError, None)
-                _G_python_110, lastError = "\b", None
+                _G_python_110, lastError = ("\b"), None
                 self.considerError(lastError, None)
                 return (_G_python_110, self.currentError)
             def _G_or_111():
                 self._trace("'f'", (782, 785), self.input.position)
                 _G_exactly_112, lastError = self.exactly('f')
                 self.considerError(lastError, None)
-                _G_python_113, lastError = "\f", None
+                _G_python_113, lastError = ("\f"), None
                 self.considerError(lastError, None)
                 return (_G_python_113, self.currentError)
             def _G_or_114():
                 self._trace('\'"\'', (816, 819), self.input.position)
                 _G_exactly_115, lastError = self.exactly('"')
                 self.considerError(lastError, None)
-                _G_python_116, lastError = '"', None
+                _G_python_116, lastError = ('"'), None
                 self.considerError(lastError, None)
                 return (_G_python_116, self.currentError)
             def _G_or_117():
                 self._trace("'\\''", (849, 853), self.input.position)
                 _G_exactly_118, lastError = self.exactly("'")
                 self.considerError(lastError, None)
-                _G_python_119, lastError = "'", None
+                _G_python_119, lastError = ("'"), None
                 self.considerError(lastError, None)
                 return (_G_python_119, self.currentError)
             def _G_or_120():
@@ -374,7 +374,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self._trace("'\\\\'", (950, 954), self.input.position)
                 _G_exactly_128, lastError = self.exactly('\\')
                 self.considerError(lastError, None)
-                _G_python_129, lastError = "\\", None
+                _G_python_129, lastError = ("\\"), None
                 self.considerError(lastError, None)
                 return (_G_python_129, self.currentError)
             _G_or_130, lastError = self._or([_G_or_99, _G_or_102, _G_or_105, _G_or_108, _G_or_111, _G_or_114, _G_or_117, _G_or_120, _G_or_127])
@@ -516,7 +516,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self.considerError(lastError, None)
                 return (_G_python_175, self.currentError)
             def _G_or_176():
-                _G_python_177, lastError = [], None
+                _G_python_177, lastError = ([]), None
                 self.considerError(lastError, None)
                 return (_G_python_177, self.currentError)
             _G_or_178, lastError = self._or([_G_or_171, _G_or_176])
@@ -883,300 +883,334 @@ def createParserClass(GrammarBase, ruleGlobals):
                     self.considerError(lastError, None)
                     return (_G_python_300, self.currentError)
                 def _G_or_301():
-                    _G_python_302, lastError = eval('r', self.globals, _locals), None
+                    self._trace(" ':('", (2787, 2792), self.input.position)
+                    _G_exactly_302, lastError = self.exactly(':(')
                     self.considerError(lastError, None)
-                    return (_G_python_302, self.currentError)
-                _G_or_303, lastError = self._or([_G_or_297, _G_or_301])
+                    self._trace(' name', (2792, 2797), self.input.position)
+                    _G_apply_303, lastError = self._apply(self.rule_name, "name", [])
+                    self.considerError(lastError, None)
+                    _locals['n'] = _G_apply_303
+                    def _G_many_304():
+                        self._trace("','", (2801, 2804), self.input.position)
+                        _G_exactly_305, lastError = self.exactly(',')
+                        self.considerError(lastError, None)
+                        self._trace(' ws', (2804, 2807), self.input.position)
+                        _G_apply_306, lastError = self._apply(self.rule_ws, "ws", [])
+                        self.considerError(lastError, None)
+                        self._trace(' name', (2807, 2812), self.input.position)
+                        _G_apply_307, lastError = self._apply(self.rule_name, "name", [])
+                        self.considerError(lastError, None)
+                        return (_G_apply_307, self.currentError)
+                    _G_many_308, lastError = self.many(_G_many_304)
+                    self.considerError(lastError, None)
+                    _locals['others'] = _G_many_308
+                    self._trace(' ws', (2821, 2824), self.input.position)
+                    _G_apply_309, lastError = self._apply(self.rule_ws, "ws", [])
+                    self.considerError(lastError, None)
+                    self._trace(" ')'", (2824, 2828), self.input.position)
+                    _G_exactly_310, lastError = self.exactly(')')
+                    self.considerError(lastError, None)
+                    _G_python_311, lastError = eval('[n] + others if others else n', self.globals, _locals), None
+                    self.considerError(lastError, None)
+                    _locals['n'] = _G_python_311
+                    _G_python_312, lastError = eval('t.Bind(n, r)', self.globals, _locals), None
+                    self.considerError(lastError, None)
+                    return (_G_python_312, self.currentError)
+                def _G_or_313():
+                    _G_python_314, lastError = eval('r', self.globals, _locals), None
+                    self.considerError(lastError, None)
+                    return (_G_python_314, self.currentError)
+                _G_or_315, lastError = self._or([_G_or_297, _G_or_301, _G_or_313])
                 self.considerError(lastError, None)
-                return (_G_or_303, self.currentError)
-            def _G_or_304():
-                self._trace('ws', (2805, 2807), self.input.position)
-                _G_apply_305, lastError = self._apply(self.rule_ws, "ws", [])
+                return (_G_or_315, self.currentError)
+            def _G_or_316():
+                self._trace('ws', (2928, 2930), self.input.position)
+                _G_apply_317, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
-                self._trace(" ':'", (2807, 2811), self.input.position)
-                _G_exactly_306, lastError = self.exactly(':')
+                self._trace(" ':'", (2930, 2934), self.input.position)
+                _G_exactly_318, lastError = self.exactly(':')
                 self.considerError(lastError, None)
-                self._trace(' name', (2811, 2816), self.input.position)
-                _G_apply_307, lastError = self._apply(self.rule_name, "name", [])
+                self._trace(' name', (2934, 2939), self.input.position)
+                _G_apply_319, lastError = self._apply(self.rule_name, "name", [])
                 self.considerError(lastError, None)
-                _locals['n'] = _G_apply_307
-                _G_python_308, lastError = eval('t.Bind(n, t.Apply("anything", self.rulename, []))', self.globals, _locals), None
+                _locals['n'] = _G_apply_319
+                _G_python_320, lastError = eval('t.Bind(n, t.Apply("anything", self.rulename, []))', self.globals, _locals), None
                 self.considerError(lastError, None)
-                return (_G_python_308, self.currentError)
-            _G_or_309, lastError = self._or([_G_or_263, _G_or_304])
+                return (_G_python_320, self.currentError)
+            _G_or_321, lastError = self._or([_G_or_263, _G_or_316])
             self.considerError(lastError, 'expr3')
-            return (_G_or_309, self.currentError)
+            return (_G_or_321, self.currentError)
 
 
         def rule_expr4(self):
             _locals = {'self': self}
             self.locals['expr4'] = _locals
-            def _G_many1_310():
-                self._trace(' expr3', (2890, 2896), self.input.position)
-                _G_apply_311, lastError = self._apply(self.rule_expr3, "expr3", [])
+            def _G_many1_322():
+                self._trace(' expr3', (3013, 3019), self.input.position)
+                _G_apply_323, lastError = self._apply(self.rule_expr3, "expr3", [])
                 self.considerError(lastError, None)
-                return (_G_apply_311, self.currentError)
-            _G_many1_312, lastError = self.many(_G_many1_310, _G_many1_310())
+                return (_G_apply_323, self.currentError)
+            _G_many1_324, lastError = self.many(_G_many1_322, _G_many1_322())
             self.considerError(lastError, 'expr4')
-            _locals['es'] = _G_many1_312
-            _G_python_313, lastError = eval('es[0] if len(es) == 1 else t.And(es)', self.globals, _locals), None
+            _locals['es'] = _G_many1_324
+            _G_python_325, lastError = eval('es[0] if len(es) == 1 else t.And(es)', self.globals, _locals), None
             self.considerError(lastError, 'expr4')
-            return (_G_python_313, self.currentError)
+            return (_G_python_325, self.currentError)
 
 
         def rule_expr(self):
             _locals = {'self': self}
             self.locals['expr'] = _locals
-            self._trace(' expr4', (2948, 2954), self.input.position)
-            _G_apply_314, lastError = self._apply(self.rule_expr4, "expr4", [])
+            self._trace(' expr4', (3071, 3077), self.input.position)
+            _G_apply_326, lastError = self._apply(self.rule_expr4, "expr4", [])
             self.considerError(lastError, 'expr')
-            _locals['e'] = _G_apply_314
-            def _G_many_315():
-                self._trace('ws', (2958, 2960), self.input.position)
-                _G_apply_316, lastError = self._apply(self.rule_ws, "ws", [])
+            _locals['e'] = _G_apply_326
+            def _G_many_327():
+                self._trace('ws', (3081, 3083), self.input.position)
+                _G_apply_328, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
-                self._trace(" '|'", (2960, 2964), self.input.position)
-                _G_exactly_317, lastError = self.exactly('|')
+                self._trace(" '|'", (3083, 3087), self.input.position)
+                _G_exactly_329, lastError = self.exactly('|')
                 self.considerError(lastError, None)
-                self._trace(' expr4', (2964, 2970), self.input.position)
-                _G_apply_318, lastError = self._apply(self.rule_expr4, "expr4", [])
+                self._trace(' expr4', (3087, 3093), self.input.position)
+                _G_apply_330, lastError = self._apply(self.rule_expr4, "expr4", [])
                 self.considerError(lastError, None)
-                return (_G_apply_318, self.currentError)
-            _G_many_319, lastError = self.many(_G_many_315)
+                return (_G_apply_330, self.currentError)
+            _G_many_331, lastError = self.many(_G_many_327)
             self.considerError(lastError, 'expr')
-            _locals['es'] = _G_many_319
-            _G_python_320, lastError = eval('t.Or([e] + es) if es else e', self.globals, _locals), None
+            _locals['es'] = _G_many_331
+            _G_python_332, lastError = eval('t.Or([e] + es) if es else e', self.globals, _locals), None
             self.considerError(lastError, 'expr')
-            return (_G_python_320, self.currentError)
+            return (_G_python_332, self.currentError)
 
 
         def rule_ruleValue(self):
             _locals = {'self': self}
             self.locals['ruleValue'] = _locals
-            self._trace(' ws', (3029, 3032), self.input.position)
-            _G_apply_321, lastError = self._apply(self.rule_ws, "ws", [])
+            self._trace(' ws', (3152, 3155), self.input.position)
+            _G_apply_333, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'ruleValue')
-            self._trace(" '->'", (3032, 3037), self.input.position)
-            _G_exactly_322, lastError = self.exactly('->')
+            self._trace(" '->'", (3155, 3160), self.input.position)
+            _G_exactly_334, lastError = self.exactly('->')
             self.considerError(lastError, 'ruleValue')
-            _G_python_323, lastError = eval('self.ruleValueExpr(True)', self.globals, _locals), None
+            _G_python_335, lastError = eval('self.ruleValueExpr(True)', self.globals, _locals), None
             self.considerError(lastError, 'ruleValue')
-            return (_G_python_323, self.currentError)
+            return (_G_python_335, self.currentError)
 
 
         def rule_customLabel(self):
             _locals = {'self': self}
             self.locals['customLabel'] = _locals
-            def _G_label_324():
-                self._trace('ws', (3082, 3084), self.input.position)
-                _G_apply_325, lastError = self._apply(self.rule_ws, "ws", [])
+            def _G_label_336():
+                self._trace('ws', (3205, 3207), self.input.position)
+                _G_apply_337, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
-                self._trace(" '^'", (3084, 3088), self.input.position)
-                _G_exactly_326, lastError = self.exactly('^')
+                self._trace(" '^'", (3207, 3211), self.input.position)
+                _G_exactly_338, lastError = self.exactly('^')
                 self.considerError(lastError, None)
-                self._trace(' ws', (3088, 3091), self.input.position)
-                _G_apply_327, lastError = self._apply(self.rule_ws, "ws", [])
+                self._trace(' ws', (3211, 3214), self.input.position)
+                _G_apply_339, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
-                self._trace(" '('", (3091, 3095), self.input.position)
-                _G_exactly_328, lastError = self.exactly('(')
+                self._trace(" '('", (3214, 3218), self.input.position)
+                _G_exactly_340, lastError = self.exactly('(')
                 self.considerError(lastError, None)
-                def _G_consumedby_329():
-                    def _G_many1_330():
-                        def _G_not_331():
-                            self._trace("')'", (3099, 3102), self.input.position)
-                            _G_exactly_332, lastError = self.exactly(')')
+                def _G_consumedby_341():
+                    def _G_many1_342():
+                        def _G_not_343():
+                            self._trace("')'", (3222, 3225), self.input.position)
+                            _G_exactly_344, lastError = self.exactly(')')
                             self.considerError(lastError, None)
-                            return (_G_exactly_332, self.currentError)
-                        _G_not_333, lastError = self._not(_G_not_331)
+                            return (_G_exactly_344, self.currentError)
+                        _G_not_345, lastError = self._not(_G_not_343)
                         self.considerError(lastError, None)
-                        self._trace(' anything', (3102, 3111), self.input.position)
-                        _G_apply_334, lastError = self._apply(self.rule_anything, "anything", [])
+                        self._trace(' anything', (3225, 3234), self.input.position)
+                        _G_apply_346, lastError = self._apply(self.rule_anything, "anything", [])
                         self.considerError(lastError, None)
-                        return (_G_apply_334, self.currentError)
-                    _G_many1_335, lastError = self.many(_G_many1_330, _G_many1_330())
+                        return (_G_apply_346, self.currentError)
+                    _G_many1_347, lastError = self.many(_G_many1_342, _G_many1_342())
                     self.considerError(lastError, None)
-                    return (_G_many1_335, self.currentError)
-                _G_consumedby_336, lastError = self.consumedby(_G_consumedby_329)
+                    return (_G_many1_347, self.currentError)
+                _G_consumedby_348, lastError = self.consumedby(_G_consumedby_341)
                 self.considerError(lastError, None)
-                _locals['e'] = _G_consumedby_336
-                self._trace(" ')'", (3116, 3120), self.input.position)
-                _G_exactly_337, lastError = self.exactly(')')
+                _locals['e'] = _G_consumedby_348
+                self._trace(" ')'", (3239, 3243), self.input.position)
+                _G_exactly_349, lastError = self.exactly(')')
                 self.considerError(lastError, None)
-                _G_python_338, lastError = eval('e', self.globals, _locals), None
+                _G_python_350, lastError = eval('e', self.globals, _locals), None
                 self.considerError(lastError, None)
-                return (_G_python_338, self.currentError)
-            _G_label_339, lastError = self.label(_G_label_324, "customLabelException")
+                return (_G_python_350, self.currentError)
+            _G_label_351, lastError = self.label(_G_label_336, "customLabelException")
             self.considerError(lastError, 'customLabel')
-            return (_G_label_339, self.currentError)
+            return (_G_label_351, self.currentError)
 
 
         def rule_semanticPredicate(self):
             _locals = {'self': self}
             self.locals['semanticPredicate'] = _locals
-            self._trace(' ws', (3172, 3175), self.input.position)
-            _G_apply_340, lastError = self._apply(self.rule_ws, "ws", [])
+            self._trace(' ws', (3295, 3298), self.input.position)
+            _G_apply_352, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'semanticPredicate')
-            self._trace(" '?('", (3175, 3180), self.input.position)
-            _G_exactly_341, lastError = self.exactly('?(')
+            self._trace(" '?('", (3298, 3303), self.input.position)
+            _G_exactly_353, lastError = self.exactly('?(')
             self.considerError(lastError, 'semanticPredicate')
-            _G_python_342, lastError = eval('self.semanticPredicateExpr()', self.globals, _locals), None
+            _G_python_354, lastError = eval('self.semanticPredicateExpr()', self.globals, _locals), None
             self.considerError(lastError, 'semanticPredicate')
-            return (_G_python_342, self.currentError)
+            return (_G_python_354, self.currentError)
 
 
         def rule_semanticAction(self):
             _locals = {'self': self}
             self.locals['semanticAction'] = _locals
-            self._trace(' ws', (3230, 3233), self.input.position)
-            _G_apply_343, lastError = self._apply(self.rule_ws, "ws", [])
+            self._trace(' ws', (3353, 3356), self.input.position)
+            _G_apply_355, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'semanticAction')
-            self._trace(" '!('", (3233, 3238), self.input.position)
-            _G_exactly_344, lastError = self.exactly('!(')
+            self._trace(" '!('", (3356, 3361), self.input.position)
+            _G_exactly_356, lastError = self.exactly('!(')
             self.considerError(lastError, 'semanticAction')
-            _G_python_345, lastError = eval('self.semanticActionExpr()', self.globals, _locals), None
+            _G_python_357, lastError = eval('self.semanticActionExpr()', self.globals, _locals), None
             self.considerError(lastError, 'semanticAction')
-            return (_G_python_345, self.currentError)
+            return (_G_python_357, self.currentError)
 
 
         def rule_ruleEnd(self):
             _locals = {'self': self}
             self.locals['ruleEnd'] = _locals
-            def _G_label_346():
-                def _G_or_347():
-                    def _G_many_348():
-                        self._trace('hspace', (3281, 3287), self.input.position)
-                        _G_apply_349, lastError = self._apply(self.rule_hspace, "hspace", [])
+            def _G_label_358():
+                def _G_or_359():
+                    def _G_many_360():
+                        self._trace('hspace', (3404, 3410), self.input.position)
+                        _G_apply_361, lastError = self._apply(self.rule_hspace, "hspace", [])
                         self.considerError(lastError, None)
-                        return (_G_apply_349, self.currentError)
-                    _G_many_350, lastError = self.many(_G_many_348)
+                        return (_G_apply_361, self.currentError)
+                    _G_many_362, lastError = self.many(_G_many_360)
                     self.considerError(lastError, None)
-                    def _G_many1_351():
-                        self._trace(' vspace', (3288, 3295), self.input.position)
-                        _G_apply_352, lastError = self._apply(self.rule_vspace, "vspace", [])
+                    def _G_many1_363():
+                        self._trace(' vspace', (3411, 3418), self.input.position)
+                        _G_apply_364, lastError = self._apply(self.rule_vspace, "vspace", [])
                         self.considerError(lastError, None)
-                        return (_G_apply_352, self.currentError)
-                    _G_many1_353, lastError = self.many(_G_many1_351, _G_many1_351())
+                        return (_G_apply_364, self.currentError)
+                    _G_many1_365, lastError = self.many(_G_many1_363, _G_many1_363())
                     self.considerError(lastError, None)
-                    return (_G_many1_353, self.currentError)
-                def _G_or_354():
-                    self._trace(' end', (3299, 3303), self.input.position)
-                    _G_apply_355, lastError = self._apply(self.rule_end, "end", [])
+                    return (_G_many1_365, self.currentError)
+                def _G_or_366():
+                    self._trace(' end', (3422, 3426), self.input.position)
+                    _G_apply_367, lastError = self._apply(self.rule_end, "end", [])
                     self.considerError(lastError, None)
-                    return (_G_apply_355, self.currentError)
-                _G_or_356, lastError = self._or([_G_or_347, _G_or_354])
+                    return (_G_apply_367, self.currentError)
+                _G_or_368, lastError = self._or([_G_or_359, _G_or_366])
                 self.considerError(lastError, None)
-                return (_G_or_356, self.currentError)
-            _G_label_357, lastError = self.label(_G_label_346, "rule end")
+                return (_G_or_368, self.currentError)
+            _G_label_369, lastError = self.label(_G_label_358, "rule end")
             self.considerError(lastError, 'ruleEnd')
-            return (_G_label_357, self.currentError)
+            return (_G_label_369, self.currentError)
 
 
         def rule_rulePart(self):
             _locals = {'self': self}
             self.locals['rulePart'] = _locals
-            _G_apply_358, lastError = self._apply(self.rule_anything, "anything", [])
+            _G_apply_370, lastError = self._apply(self.rule_anything, "anything", [])
             self.considerError(lastError, 'rulePart')
-            _locals['requiredName'] = _G_apply_358
-            self._trace(' noindentation', (3343, 3357), self.input.position)
-            _G_apply_359, lastError = self._apply(self.rule_noindentation, "noindentation", [])
+            _locals['requiredName'] = _G_apply_370
+            self._trace(' noindentation', (3466, 3480), self.input.position)
+            _G_apply_371, lastError = self._apply(self.rule_noindentation, "noindentation", [])
             self.considerError(lastError, 'rulePart')
-            self._trace(' name', (3357, 3362), self.input.position)
-            _G_apply_360, lastError = self._apply(self.rule_name, "name", [])
+            self._trace(' name', (3480, 3485), self.input.position)
+            _G_apply_372, lastError = self._apply(self.rule_name, "name", [])
             self.considerError(lastError, 'rulePart')
-            _locals['n'] = _G_apply_360
-            def _G_pred_361():
-                _G_python_362, lastError = eval('n == requiredName', self.globals, _locals), None
-                self.considerError(lastError, None)
-                return (_G_python_362, self.currentError)
-            _G_pred_363, lastError = self.pred(_G_pred_361)
-            self.considerError(lastError, 'rulePart')
-            _G_python_364, lastError = eval('setattr(self, "rulename", n)', self.globals, _locals), None
-            self.considerError(lastError, 'rulePart')
-            def _G_optional_365():
-                self._trace('\n                            expr4', (3445, 3479), self.input.position)
-                _G_apply_366, lastError = self._apply(self.rule_expr4, "expr4", [])
-                self.considerError(lastError, None)
-                return (_G_apply_366, self.currentError)
-            def _G_optional_367():
-                return (None, self.input.nullError())
-            _G_or_368, lastError = self._or([_G_optional_365, _G_optional_367])
-            self.considerError(lastError, 'rulePart')
-            _locals['args'] = _G_or_368
-            def _G_or_369():
-                self._trace('ws', (3515, 3517), self.input.position)
-                _G_apply_370, lastError = self._apply(self.rule_ws, "ws", [])
-                self.considerError(lastError, None)
-                self._trace(" '='", (3517, 3521), self.input.position)
-                _G_exactly_371, lastError = self.exactly('=')
-                self.considerError(lastError, None)
-                self._trace(' expr', (3521, 3526), self.input.position)
-                _G_apply_372, lastError = self._apply(self.rule_expr, "expr", [])
-                self.considerError(lastError, None)
-                _locals['e'] = _G_apply_372
-                self._trace(' ruleEnd', (3528, 3536), self.input.position)
-                _G_apply_373, lastError = self._apply(self.rule_ruleEnd, "ruleEnd", [])
-                self.considerError(lastError, None)
-                _G_python_374, lastError = eval('t.And([args, e]) if args else e', self.globals, _locals), None
+            _locals['n'] = _G_apply_372
+            def _G_pred_373():
+                _G_python_374, lastError = eval('n == requiredName', self.globals, _locals), None
                 self.considerError(lastError, None)
                 return (_G_python_374, self.currentError)
-            def _G_or_375():
-                self._trace(' ruleEnd', (3632, 3640), self.input.position)
-                _G_apply_376, lastError = self._apply(self.rule_ruleEnd, "ruleEnd", [])
-                self.considerError(lastError, None)
-                _G_python_377, lastError = eval('args', self.globals, _locals), None
-                self.considerError(lastError, None)
-                return (_G_python_377, self.currentError)
-            _G_or_378, lastError = self._or([_G_or_369, _G_or_375])
+            _G_pred_375, lastError = self.pred(_G_pred_373)
             self.considerError(lastError, 'rulePart')
-            return (_G_or_378, self.currentError)
+            _G_python_376, lastError = eval('setattr(self, "rulename", n)', self.globals, _locals), None
+            self.considerError(lastError, 'rulePart')
+            def _G_optional_377():
+                self._trace('\n                            expr4', (3568, 3602), self.input.position)
+                _G_apply_378, lastError = self._apply(self.rule_expr4, "expr4", [])
+                self.considerError(lastError, None)
+                return (_G_apply_378, self.currentError)
+            def _G_optional_379():
+                return (None, self.input.nullError())
+            _G_or_380, lastError = self._or([_G_optional_377, _G_optional_379])
+            self.considerError(lastError, 'rulePart')
+            _locals['args'] = _G_or_380
+            def _G_or_381():
+                self._trace('ws', (3638, 3640), self.input.position)
+                _G_apply_382, lastError = self._apply(self.rule_ws, "ws", [])
+                self.considerError(lastError, None)
+                self._trace(" '='", (3640, 3644), self.input.position)
+                _G_exactly_383, lastError = self.exactly('=')
+                self.considerError(lastError, None)
+                self._trace(' expr', (3644, 3649), self.input.position)
+                _G_apply_384, lastError = self._apply(self.rule_expr, "expr", [])
+                self.considerError(lastError, None)
+                _locals['e'] = _G_apply_384
+                self._trace(' ruleEnd', (3651, 3659), self.input.position)
+                _G_apply_385, lastError = self._apply(self.rule_ruleEnd, "ruleEnd", [])
+                self.considerError(lastError, None)
+                _G_python_386, lastError = eval('t.And([args, e]) if args else e', self.globals, _locals), None
+                self.considerError(lastError, None)
+                return (_G_python_386, self.currentError)
+            def _G_or_387():
+                self._trace(' ruleEnd', (3755, 3763), self.input.position)
+                _G_apply_388, lastError = self._apply(self.rule_ruleEnd, "ruleEnd", [])
+                self.considerError(lastError, None)
+                _G_python_389, lastError = eval('args', self.globals, _locals), None
+                self.considerError(lastError, None)
+                return (_G_python_389, self.currentError)
+            _G_or_390, lastError = self._or([_G_or_381, _G_or_387])
+            self.considerError(lastError, 'rulePart')
+            return (_G_or_390, self.currentError)
 
 
         def rule_rule(self):
             _locals = {'self': self}
             self.locals['rule'] = _locals
-            self._trace(' noindentation', (3657, 3671), self.input.position)
-            _G_apply_379, lastError = self._apply(self.rule_noindentation, "noindentation", [])
+            self._trace(' noindentation', (3780, 3794), self.input.position)
+            _G_apply_391, lastError = self._apply(self.rule_noindentation, "noindentation", [])
             self.considerError(lastError, 'rule')
-            def _G_lookahead_380():
-                self._trace('name', (3675, 3679), self.input.position)
-                _G_apply_381, lastError = self._apply(self.rule_name, "name", [])
+            def _G_lookahead_392():
+                self._trace('name', (3798, 3802), self.input.position)
+                _G_apply_393, lastError = self._apply(self.rule_name, "name", [])
                 self.considerError(lastError, None)
-                _locals['n'] = _G_apply_381
+                _locals['n'] = _G_apply_393
                 return (_locals['n'], self.currentError)
-            _G_lookahead_382, lastError = self.lookahead(_G_lookahead_380)
+            _G_lookahead_394, lastError = self.lookahead(_G_lookahead_392)
             self.considerError(lastError, 'rule')
-            def _G_many1_383():
-                self._trace(' rulePart(n)', (3682, 3694), self.input.position)
-                _G_python_384, lastError = eval('n', self.globals, _locals), None
+            def _G_many1_395():
+                self._trace(' rulePart(n)', (3805, 3817), self.input.position)
+                _G_python_396, lastError = eval('n', self.globals, _locals), None
                 self.considerError(lastError, None)
-                _G_apply_385, lastError = self._apply(self.rule_rulePart, "rulePart", [_G_python_384])
+                _G_apply_397, lastError = self._apply(self.rule_rulePart, "rulePart", [_G_python_396])
                 self.considerError(lastError, None)
-                return (_G_apply_385, self.currentError)
-            _G_many1_386, lastError = self.many(_G_many1_383, _G_many1_383())
+                return (_G_apply_397, self.currentError)
+            _G_many1_398, lastError = self.many(_G_many1_395, _G_many1_395())
             self.considerError(lastError, 'rule')
-            _locals['rs'] = _G_many1_386
-            _G_python_387, lastError = eval('t.Rule(n, t.Or(rs))', self.globals, _locals), None
+            _locals['rs'] = _G_many1_398
+            _G_python_399, lastError = eval('t.Rule(n, t.Or(rs))', self.globals, _locals), None
             self.considerError(lastError, 'rule')
-            return (_G_python_387, self.currentError)
+            return (_G_python_399, self.currentError)
 
 
         def rule_grammar(self):
             _locals = {'self': self}
             self.locals['grammar'] = _locals
-            def _G_many_388():
-                self._trace(' rule', (3733, 3738), self.input.position)
-                _G_apply_389, lastError = self._apply(self.rule_rule, "rule", [])
+            def _G_many_400():
+                self._trace(' rule', (3856, 3861), self.input.position)
+                _G_apply_401, lastError = self._apply(self.rule_rule, "rule", [])
                 self.considerError(lastError, None)
-                return (_G_apply_389, self.currentError)
-            _G_many_390, lastError = self.many(_G_many_388)
+                return (_G_apply_401, self.currentError)
+            _G_many_402, lastError = self.many(_G_many_400)
             self.considerError(lastError, 'grammar')
-            _locals['rs'] = _G_many_390
-            self._trace(' ws', (3742, 3745), self.input.position)
-            _G_apply_391, lastError = self._apply(self.rule_ws, "ws", [])
+            _locals['rs'] = _G_many_402
+            self._trace(' ws', (3865, 3868), self.input.position)
+            _G_apply_403, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'grammar')
-            _G_python_392, lastError = eval('t.Grammar(self.name, self.tree_target, rs)', self.globals, _locals), None
+            _G_python_404, lastError = eval('t.Grammar(self.name, self.tree_target, rs)', self.globals, _locals), None
             self.considerError(lastError, 'grammar')
-            return (_G_python_392, self.currentError)
+            return (_G_python_404, self.currentError)
 
 
     if parsley.globals is not None:

--- a/ometa/_generated/parsley_tree_transformer.py
+++ b/ometa/_generated/parsley_tree_transformer.py
@@ -532,7 +532,7 @@ def createParserClass(GrammarBase, ruleGlobals):
             self.considerError(lastError, 'termRulePart')
             def _G_optional_185():
                 self._trace(' token("=")', (1425, 1436), self.input.position)
-                _G_python_186, lastError = "=", None
+                _G_python_186, lastError = ("="), None
                 self.considerError(lastError, None)
                 _G_apply_187, lastError = self._apply(self.rule_token, "token", [_G_python_186])
                 self.considerError(lastError, None)

--- a/ometa/_generated/pymeta_v1.py
+++ b/ometa/_generated/pymeta_v1.py
@@ -247,56 +247,56 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self._trace("'n'", (486, 489), self.input.position)
                 _G_exactly_82, lastError = self.exactly('n')
                 self.considerError(lastError, None)
-                _G_python_83, lastError = "\n", None
+                _G_python_83, lastError = ("\n"), None
                 self.considerError(lastError, None)
                 return (_G_python_83, self.currentError)
             def _G_or_84():
                 self._trace("'r'", (520, 523), self.input.position)
                 _G_exactly_85, lastError = self.exactly('r')
                 self.considerError(lastError, None)
-                _G_python_86, lastError = "\r", None
+                _G_python_86, lastError = ("\r"), None
                 self.considerError(lastError, None)
                 return (_G_python_86, self.currentError)
             def _G_or_87():
                 self._trace("'t'", (554, 557), self.input.position)
                 _G_exactly_88, lastError = self.exactly('t')
                 self.considerError(lastError, None)
-                _G_python_89, lastError = "\t", None
+                _G_python_89, lastError = ("\t"), None
                 self.considerError(lastError, None)
                 return (_G_python_89, self.currentError)
             def _G_or_90():
                 self._trace("'b'", (588, 591), self.input.position)
                 _G_exactly_91, lastError = self.exactly('b')
                 self.considerError(lastError, None)
-                _G_python_92, lastError = "\b", None
+                _G_python_92, lastError = ("\b"), None
                 self.considerError(lastError, None)
                 return (_G_python_92, self.currentError)
             def _G_or_93():
                 self._trace("'f'", (622, 625), self.input.position)
                 _G_exactly_94, lastError = self.exactly('f')
                 self.considerError(lastError, None)
-                _G_python_95, lastError = "\f", None
+                _G_python_95, lastError = ("\f"), None
                 self.considerError(lastError, None)
                 return (_G_python_95, self.currentError)
             def _G_or_96():
                 self._trace('\'"\'', (656, 659), self.input.position)
                 _G_exactly_97, lastError = self.exactly('"')
                 self.considerError(lastError, None)
-                _G_python_98, lastError = '"', None
+                _G_python_98, lastError = ('"'), None
                 self.considerError(lastError, None)
                 return (_G_python_98, self.currentError)
             def _G_or_99():
                 self._trace("'\\''", (689, 693), self.input.position)
                 _G_exactly_100, lastError = self.exactly("'")
                 self.considerError(lastError, None)
-                _G_python_101, lastError = "'", None
+                _G_python_101, lastError = ("'"), None
                 self.considerError(lastError, None)
                 return (_G_python_101, self.currentError)
             def _G_or_102():
                 self._trace("'\\\\'", (723, 727), self.input.position)
                 _G_exactly_103, lastError = self.exactly('\\')
                 self.considerError(lastError, None)
-                _G_python_104, lastError = "\\", None
+                _G_python_104, lastError = ("\\"), None
                 self.considerError(lastError, None)
                 return (_G_python_104, self.currentError)
             _G_or_105, lastError = self._or([_G_or_81, _G_or_84, _G_or_87, _G_or_90, _G_or_93, _G_or_96, _G_or_99, _G_or_102])

--- a/ometa/builder.py
+++ b/ometa/builder.py
@@ -107,7 +107,7 @@ class PythonWriter(object):
         """
         try:
             ast.literal_eval(expr)
-            return self._expr(out, 'python', expr + ', None', debugname)
+            return self._expr(out, 'python', '(' + expr + '), None', debugname)
         except ValueError:
             return self._expr(out, 'python',
                               'eval(%r, self.globals, _locals), None' % (expr,),
@@ -250,9 +250,14 @@ class PythonWriter(object):
         Bind the value of 'expr' to a name in the _locals dict.
         """
         v = self._generateNode(out, expr, debugname)
-        ref = "_locals['%s']" % (name.data,)
-        out.writeln("%s = %s" %(ref, v))
-        return ref
+        if name.data:
+            ref = "_locals['%s']" % (name.data,)
+            out.writeln("%s = %s" % (ref, v))
+        else:
+            for i, n in enumerate(name.args):
+                ref = "_locals['%s']" % (n.data,)
+                out.writeln("%s = %s[%i]" %(ref, v, i))
+        return v
 
 
     def generate_Predicate(self, out, expr, debugname=None):

--- a/ometa/interp.py
+++ b/ometa/interp.py
@@ -395,7 +395,11 @@ class TrampolinedGrammarInterpreter(object):
         for x in self._eval(expr):
             if x is _feed_me: yield x
         v, err = x
-        self._localsStack[-1][name.data] = v
+        if name.data:
+            self._localsStack[-1][name.data] = v
+        else:
+            for n, val in zip(name.args, v):
+                self._localsStack[-1][n.data] = val
         yield v, err
 
 
@@ -637,7 +641,11 @@ class GrammarInterpreter(object):
 
         elif name == "Bind":
             v, err =  self._eval(run, args[1])
-            self._localsStack[-1][args[0].data] = v
+            if args[0].data:
+                self._localsStack[-1][args[0].data] = v
+            else:
+                for n, val in zip(args[0].args, v):
+                    self._localsStack[-1][n.data] = val
             return v, err
 
         elif name == "Predicate":

--- a/ometa/parsley.parsley
+++ b/ometa/parsley.parsley
@@ -81,6 +81,8 @@ expr3 = (expr2:e
                       | -> e
 )):r
            (':' name:n -> t.Bind(n, r)
+           | ':(' name:n (',' ws name)*:others ws ')'
+                (-> [n] + others if others else n):n -> t.Bind(n, r)
            | -> r)
           |ws ':' name:n
           -> t.Bind(n, t.Apply("anything", self.rulename, []))

--- a/ometa/test/test_builder.py
+++ b/ometa/test/test_builder.py
@@ -38,7 +38,7 @@ class PythonWriterTests(unittest.TestCase):
         a = t.Apply("foo", "main", [one, x])
         self.assertEqual(writePython(a, ""),
                          dd("""
-                            _G_python_1, lastError = 1, None
+                            _G_python_1, lastError = (1), None
                             self.considerError(lastError, None)
                             _G_python_2, lastError = eval('x', self.globals, _locals), None
                             self.considerError(lastError, None)
@@ -56,7 +56,7 @@ class PythonWriterTests(unittest.TestCase):
         a = t.ForeignApply("thegrammar", "foo", "main", [one, x])
         self.assertEqual(writePython(a, ""),
                          dd("""
-                            _G_python_1, lastError = 1, None
+                            _G_python_1, lastError = (1), None
                             self.considerError(lastError, None)
                             _G_python_2, lastError = eval('x', self.globals, _locals), None
                             self.considerError(lastError, None)
@@ -75,7 +75,7 @@ class PythonWriterTests(unittest.TestCase):
         a = t.Apply("super", "main", [one, x])
         self.assertEqual(writePython(a, ""),
                          dd("""
-                            _G_python_1, lastError = 1, None
+                            _G_python_1, lastError = (1), None
                             self.considerError(lastError, None)
                             _G_python_2, lastError = eval('x', self.globals, _locals), None
                             self.considerError(lastError, None)
@@ -238,7 +238,7 @@ class PythonWriterTests(unittest.TestCase):
                             _G_exactly_1, lastError = self.exactly('x')
                             self.considerError(lastError, None)
                             _locals['var'] = _G_exactly_1
-                            _locals['var']
+                            _G_exactly_1
                             """))
 
 

--- a/ometa/test/test_pymeta.py
+++ b/ometa/test/test_pymeta.py
@@ -640,10 +640,17 @@ class OMetaTestCase(unittest.TestCase):
 
     def test_binding(self):
         """
-        The result of a parsing expression can be bound to a name.
+        The result of a parsing expression can be bound to a single name
+        or names surrounded by parentheses.
         """
         g = self.compile("foo = '1':x -> int(x) * 2")
         self.assertEqual(g.foo("1"), 2)
+        g = self.compile("foo = '1':(x) -> int(x) * 2")
+        self.assertEqual(g.foo("1"), 2)
+        g = self.compile("foo = (-> 3, 4):(x, y) -> x")
+        self.assertEqual(g.foo(""), 3)
+        g = self.compile("foo = (-> 1, 2):(x, y) -> int(x) * 2 + int(y)")
+        self.assertEqual(g.foo(""), 4)
 
 
     def test_bindingAccess(self):
@@ -660,6 +667,18 @@ class OMetaTestCase(unittest.TestCase):
         self.assertEqual(g.apply("stuff")[0], '3')
         self.assertEqual(g.locals['stuff']['a'], '1')
         self.assertEqual(g.locals['stuff']['c'], '3')
+        G = self.classTested.makeGrammar(
+            "stuff = '1':a ('2':(b) | '345':(c, d, e))", 'TestGrammar').createParserClass(OMetaBase, {})
+        g = G("12")
+        self.assertEqual(g.apply("stuff")[0], '2')
+        self.assertEqual(g.locals['stuff']['a'], '1')
+        self.assertEqual(g.locals['stuff']['b'], '2')
+        g = G("1345")
+        self.assertEqual(g.apply("stuff")[0], '345')
+        self.assertEqual(g.locals['stuff']['a'], '1')
+        self.assertEqual(g.locals['stuff']['c'], '3')
+        self.assertEqual(g.locals['stuff']['d'], '4')
+        self.assertEqual(g.locals['stuff']['e'], '5')
 
 
     def test_predicate(self):

--- a/terml/_generated/quasiterm.py
+++ b/terml/_generated/quasiterm.py
@@ -6,6 +6,7 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['schema'] = _locals
             def _G_many1_1():
+                self._trace(' production', (8, 19), self.input.position)
                 _G_apply_2, lastError = self._apply(self.rule_production, "production", [])
                 self.considerError(lastError, None)
                 return (_G_apply_2, self.currentError)
@@ -20,18 +21,24 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_production(self):
             _locals = {'self': self}
             self.locals['production'] = _locals
+            self._trace(' tag', (50, 54), self.input.position)
             _G_apply_5, lastError = self._apply(self.rule_tag, "tag", [])
             self.considerError(lastError, 'production')
             _locals['t'] = _G_apply_5
+            self._trace(' ws', (56, 59), self.input.position)
             _G_apply_6, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'production')
+            self._trace(" '::='", (59, 65), self.input.position)
             _G_exactly_7, lastError = self.exactly('::=')
             self.considerError(lastError, 'production')
+            self._trace(' argList', (65, 73), self.input.position)
             _G_apply_8, lastError = self._apply(self.rule_argList, "argList", [])
             self.considerError(lastError, 'production')
             _locals['a'] = _G_apply_8
+            self._trace(' ws', (75, 78), self.input.position)
             _G_apply_9, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'production')
+            self._trace(" ';'", (78, 82), self.input.position)
             _G_exactly_10, lastError = self.exactly(';')
             self.considerError(lastError, 'production')
             _G_python_11, lastError = eval('production(t, a)', self.globals, _locals), None
@@ -43,11 +50,14 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['functor'] = _locals
             def _G_or_12():
+                self._trace('spaces', (115, 121), self.input.position)
                 _G_apply_13, lastError = self._apply(self.rule_spaces, "spaces", [])
                 self.considerError(lastError, None)
                 def _G_or_14():
+                    self._trace('functorHole', (125, 136), self.input.position)
                     _G_apply_15, lastError = self._apply(self.rule_functorHole, "functorHole", [])
                     self.considerError(lastError, None)
+                    self._trace(' functorHole', (136, 148), self.input.position)
                     _G_apply_16, lastError = self._apply(self.rule_functorHole, "functorHole", [])
                     self.considerError(lastError, None)
                     _G_python_17, lastError = eval('reserved("hole-tagged-hole")', self.globals, _locals), None
@@ -55,6 +65,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                     return (_G_python_17, self.currentError)
                 def _G_or_18():
                     def _G_optional_19():
+                        self._trace("'.'", (203, 206), self.input.position)
                         _G_exactly_20, lastError = self.exactly('.')
                         self.considerError(lastError, None)
                         return (_G_exactly_20, self.currentError)
@@ -62,13 +73,16 @@ def createParserClass(GrammarBase, ruleGlobals):
                         return (None, self.input.nullError())
                     _G_or_22, lastError = self._or([_G_optional_19, _G_optional_21])
                     self.considerError(lastError, None)
+                    self._trace(' functorHole', (207, 219), self.input.position)
                     _G_apply_23, lastError = self._apply(self.rule_functorHole, "functorHole", [])
                     self.considerError(lastError, None)
                     return (_G_apply_23, self.currentError)
                 def _G_or_24():
+                    self._trace('tag', (242, 245), self.input.position)
                     _G_apply_25, lastError = self._apply(self.rule_tag, "tag", [])
                     self.considerError(lastError, None)
                     _locals['t'] = _G_apply_25
+                    self._trace(' functorHole', (247, 259), self.input.position)
                     _G_apply_26, lastError = self._apply(self.rule_functorHole, "functorHole", [])
                     self.considerError(lastError, None)
                     _locals['h'] = _G_apply_26
@@ -79,6 +93,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self.considerError(lastError, None)
                 return (_G_or_28, self.currentError)
             def _G_or_29():
+                self._trace(' super', (296, 302), self.input.position)
                 _G_apply_30, lastError = self.superApply("functor", )
                 self.considerError(lastError, None)
                 return (_G_apply_30, self.currentError)
@@ -90,14 +105,18 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_arg(self):
             _locals = {'self': self}
             self.locals['arg'] = _locals
+            self._trace(' interleave', (309, 320), self.input.position)
             _G_apply_32, lastError = self._apply(self.rule_interleave, "interleave", [])
             self.considerError(lastError, 'arg')
             _locals['l'] = _G_apply_32
             def _G_many_33():
+                self._trace('ws', (324, 326), self.input.position)
                 _G_apply_34, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
+                self._trace(" '|'", (326, 330), self.input.position)
                 _G_exactly_35, lastError = self.exactly('|')
                 self.considerError(lastError, None)
+                self._trace(' interleave', (330, 341), self.input.position)
                 _G_apply_36, lastError = self._apply(self.rule_interleave, "interleave", [])
                 self.considerError(lastError, None)
                 return (_G_apply_36, self.currentError)
@@ -112,14 +131,18 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_interleave(self):
             _locals = {'self': self}
             self.locals['interleave'] = _locals
+            self._trace(' action', (372, 379), self.input.position)
             _G_apply_39, lastError = self._apply(self.rule_action, "action", [])
             self.considerError(lastError, 'interleave')
             _locals['l'] = _G_apply_39
             def _G_many_40():
+                self._trace('ws', (383, 385), self.input.position)
                 _G_apply_41, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
+                self._trace(" '&'", (385, 389), self.input.position)
                 _G_exactly_42, lastError = self.exactly('&')
                 self.considerError(lastError, None)
+                self._trace(' action', (389, 396), self.input.position)
                 _G_apply_43, lastError = self._apply(self.rule_action, "action", [])
                 self.considerError(lastError, None)
                 return (_G_apply_43, self.currentError)
@@ -134,14 +157,18 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_action(self):
             _locals = {'self': self}
             self.locals['action'] = _locals
+            self._trace(' pred', (430, 435), self.input.position)
             _G_apply_46, lastError = self._apply(self.rule_pred, "pred", [])
             self.considerError(lastError, 'action')
             _locals['l'] = _G_apply_46
             def _G_or_47():
+                self._trace('ws', (439, 441), self.input.position)
                 _G_apply_48, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
+                self._trace(" '->'", (441, 446), self.input.position)
                 _G_exactly_49, lastError = self.exactly('->')
                 self.considerError(lastError, None)
+                self._trace(' pred', (446, 451), self.input.position)
                 _G_apply_50, lastError = self._apply(self.rule_pred, "pred", [])
                 self.considerError(lastError, None)
                 _locals['r'] = _G_apply_50
@@ -161,14 +188,18 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['pred'] = _locals
             def _G_or_55():
+                self._trace(' some', (519, 524), self.input.position)
                 _G_apply_56, lastError = self._apply(self.rule_some, "some", [])
                 self.considerError(lastError, None)
                 return (_G_apply_56, self.currentError)
             def _G_or_57():
+                self._trace('ws', (528, 530), self.input.position)
                 _G_apply_58, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
+                self._trace(" '!'", (530, 534), self.input.position)
                 _G_exactly_59, lastError = self.exactly('!')
                 self.considerError(lastError, None)
+                self._trace(' some', (534, 539), self.input.position)
                 _G_apply_60, lastError = self._apply(self.rule_some, "some", [])
                 self.considerError(lastError, None)
                 _locals['x'] = _G_apply_60
@@ -184,6 +215,7 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['some'] = _locals
             def _G_or_63():
+                self._trace('quant', (561, 566), self.input.position)
                 _G_apply_64, lastError = self._apply(self.rule_quant, "quant", [])
                 self.considerError(lastError, None)
                 _locals['q'] = _G_apply_64
@@ -191,15 +223,19 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self.considerError(lastError, None)
                 return (_G_python_65, self.currentError)
             def _G_or_66():
+                self._trace(' prim', (596, 601), self.input.position)
                 _G_apply_67, lastError = self._apply(self.rule_prim, "prim", [])
                 self.considerError(lastError, None)
                 _locals['l'] = _G_apply_67
                 def _G_optional_68():
                     def _G_or_69():
+                        self._trace('ws', (607, 609), self.input.position)
                         _G_apply_70, lastError = self._apply(self.rule_ws, "ws", [])
                         self.considerError(lastError, None)
+                        self._trace(" '**'", (609, 614), self.input.position)
                         _G_exactly_71, lastError = self.exactly('**')
                         self.considerError(lastError, None)
+                        self._trace(' prim', (614, 619), self.input.position)
                         _G_apply_72, lastError = self._apply(self.rule_prim, "prim", [])
                         self.considerError(lastError, None)
                         _locals['r'] = _G_apply_72
@@ -207,10 +243,13 @@ def createParserClass(GrammarBase, ruleGlobals):
                         self.considerError(lastError, None)
                         return (_G_python_73, self.currentError)
                     def _G_or_74():
+                        self._trace('ws', (676, 678), self.input.position)
                         _G_apply_75, lastError = self._apply(self.rule_ws, "ws", [])
                         self.considerError(lastError, None)
+                        self._trace(" '++'", (678, 683), self.input.position)
                         _G_exactly_76, lastError = self.exactly('++')
                         self.considerError(lastError, None)
+                        self._trace(' prim', (683, 688), self.input.position)
                         _G_apply_77, lastError = self._apply(self.rule_prim, "prim", [])
                         self.considerError(lastError, None)
                         _locals['r'] = _G_apply_77
@@ -226,6 +265,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self.considerError(lastError, None)
                 _locals['seq'] = _G_or_81
                 def _G_optional_82():
+                    self._trace('\n           quant', (749, 766), self.input.position)
                     _G_apply_83, lastError = self._apply(self.rule_quant, "quant", [])
                     self.considerError(lastError, None)
                     return (_G_apply_83, self.currentError)
@@ -245,17 +285,21 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_quant(self):
             _locals = {'self': self}
             self.locals['quant'] = _locals
+            self._trace(' ws', (800, 803), self.input.position)
             _G_apply_88, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'quant')
             def _G_or_89():
+                self._trace("'?'", (805, 808), self.input.position)
                 _G_exactly_90, lastError = self.exactly('?')
                 self.considerError(lastError, None)
                 return (_G_exactly_90, self.currentError)
             def _G_or_91():
+                self._trace("'+'", (810, 813), self.input.position)
                 _G_exactly_92, lastError = self.exactly('+')
                 self.considerError(lastError, None)
                 return (_G_exactly_92, self.currentError)
             def _G_or_93():
+                self._trace(" '*'", (815, 819), self.input.position)
                 _G_exactly_94, lastError = self.exactly('*')
                 self.considerError(lastError, None)
                 return (_G_exactly_94, self.currentError)
@@ -268,23 +312,29 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['prim'] = _locals
             def _G_or_96():
+                self._trace(' term', (827, 832), self.input.position)
                 _G_apply_97, lastError = self._apply(self.rule_term, "term", [])
                 self.considerError(lastError, None)
                 return (_G_apply_97, self.currentError)
             def _G_or_98():
+                self._trace("'.'", (841, 844), self.input.position)
                 _G_exactly_99, lastError = self.exactly('.')
                 self.considerError(lastError, None)
                 _G_python_100, lastError = eval('any()', self.globals, _locals), None
                 self.considerError(lastError, None)
                 return (_G_python_100, self.currentError)
             def _G_or_101():
+                self._trace('literal', (863, 870), self.input.position)
                 _G_apply_102, lastError = self._apply(self.rule_literal, "literal", [])
                 self.considerError(lastError, None)
                 _locals['l'] = _G_apply_102
+                self._trace(' ws', (872, 875), self.input.position)
                 _G_apply_103, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
+                self._trace(" '..'", (875, 880), self.input.position)
                 _G_exactly_104, lastError = self.exactly('..')
                 self.considerError(lastError, None)
+                self._trace(' literal', (880, 888), self.input.position)
                 _G_apply_105, lastError = self._apply(self.rule_literal, "literal", [])
                 self.considerError(lastError, None)
                 _locals['r'] = _G_apply_105
@@ -292,10 +342,13 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self.considerError(lastError, None)
                 return (_G_python_106, self.currentError)
             def _G_or_107():
+                self._trace(' ws', (913, 916), self.input.position)
                 _G_apply_108, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
+                self._trace(" '^'", (916, 920), self.input.position)
                 _G_exactly_109, lastError = self.exactly('^')
                 self.considerError(lastError, None)
+                self._trace(' string', (920, 927), self.input.position)
                 _G_apply_110, lastError = self._apply(self.rule_string, "string", [])
                 self.considerError(lastError, None)
                 _locals['s'] = _G_apply_110
@@ -303,15 +356,20 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self.considerError(lastError, None)
                 return (_G_python_111, self.currentError)
             def _G_or_112():
+                self._trace(' ws', (948, 951), self.input.position)
                 _G_apply_113, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
+                self._trace(" '('", (951, 955), self.input.position)
                 _G_exactly_114, lastError = self.exactly('(')
                 self.considerError(lastError, None)
+                self._trace(' argList', (955, 963), self.input.position)
                 _G_apply_115, lastError = self._apply(self.rule_argList, "argList", [])
                 self.considerError(lastError, None)
                 _locals['l'] = _G_apply_115
+                self._trace(' ws', (965, 968), self.input.position)
                 _G_apply_116, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
+                self._trace(" ')'", (968, 972), self.input.position)
                 _G_exactly_117, lastError = self.exactly(')')
                 self.considerError(lastError, None)
                 _G_python_118, lastError = eval('l', self.globals, _locals), None
@@ -325,6 +383,7 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_simpleint(self):
             _locals = {'self': self}
             self.locals['simpleint'] = _locals
+            self._trace(' decdigits', (990, 1000), self.input.position)
             _G_apply_120, lastError = self._apply(self.rule_decdigits, "decdigits", [])
             self.considerError(lastError, 'simpleint')
             _locals['ds'] = _G_apply_120
@@ -337,23 +396,29 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['functorHole'] = _locals
             def _G_or_122():
+                self._trace(" '$'", (1028, 1032), self.input.position)
                 _G_exactly_123, lastError = self.exactly('$')
                 self.considerError(lastError, None)
                 def _G_or_124():
+                    self._trace('simpleint', (1041, 1050), self.input.position)
                     _G_apply_125, lastError = self._apply(self.rule_simpleint, "simpleint", [])
                     self.considerError(lastError, None)
                     _locals['i'] = _G_apply_125
                     return (_locals['i'], self.currentError)
                 def _G_or_126():
+                    self._trace(" '{'", (1054, 1058), self.input.position)
                     _G_exactly_127, lastError = self.exactly('{')
                     self.considerError(lastError, None)
+                    self._trace(' simpleint', (1058, 1068), self.input.position)
                     _G_apply_128, lastError = self._apply(self.rule_simpleint, "simpleint", [])
                     self.considerError(lastError, None)
                     _locals['i'] = _G_apply_128
+                    self._trace(" '}'", (1070, 1074), self.input.position)
                     _G_exactly_129, lastError = self.exactly('}')
                     self.considerError(lastError, None)
                     return (_G_exactly_129, self.currentError)
                 def _G_or_130():
+                    self._trace('tag', (1078, 1081), self.input.position)
                     _G_apply_131, lastError = self._apply(self.rule_tag, "tag", [])
                     self.considerError(lastError, None)
                     _locals['t'] = _G_apply_131
@@ -368,30 +433,37 @@ def createParserClass(GrammarBase, ruleGlobals):
                 return (_G_python_134, self.currentError)
             def _G_or_135():
                 def _G_or_136():
+                    self._trace("'@'", (1129, 1132), self.input.position)
                     _G_exactly_137, lastError = self.exactly('@')
                     self.considerError(lastError, None)
                     return (_G_exactly_137, self.currentError)
                 def _G_or_138():
+                    self._trace(" '='", (1134, 1138), self.input.position)
                     _G_exactly_139, lastError = self.exactly('=')
                     self.considerError(lastError, None)
                     return (_G_exactly_139, self.currentError)
                 _G_or_140, lastError = self._or([_G_or_136, _G_or_138])
                 self.considerError(lastError, None)
                 def _G_or_141():
+                    self._trace('simpleint', (1141, 1150), self.input.position)
                     _G_apply_142, lastError = self._apply(self.rule_simpleint, "simpleint", [])
                     self.considerError(lastError, None)
                     _locals['i'] = _G_apply_142
                     return (_locals['i'], self.currentError)
                 def _G_or_143():
+                    self._trace(" '{'", (1154, 1158), self.input.position)
                     _G_exactly_144, lastError = self.exactly('{')
                     self.considerError(lastError, None)
+                    self._trace(' simpleint', (1158, 1168), self.input.position)
                     _G_apply_145, lastError = self._apply(self.rule_simpleint, "simpleint", [])
                     self.considerError(lastError, None)
                     _locals['i'] = _G_apply_145
+                    self._trace(" '}'", (1170, 1174), self.input.position)
                     _G_exactly_146, lastError = self.exactly('}')
                     self.considerError(lastError, None)
                     return (_G_exactly_146, self.currentError)
                 def _G_or_147():
+                    self._trace('tag', (1178, 1181), self.input.position)
                     _G_apply_148, lastError = self._apply(self.rule_tag, "tag", [])
                     self.considerError(lastError, None)
                     _locals['t'] = _G_apply_148

--- a/terml/_generated/terml.py
+++ b/terml/_generated/terml.py
@@ -6,27 +6,33 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['hspace'] = _locals
             def _G_or_1():
+                self._trace("' '", (10, 13), self.input.position)
                 _G_exactly_2, lastError = self.exactly(' ')
                 self.considerError(lastError, None)
                 return (_G_exactly_2, self.currentError)
             def _G_or_3():
+                self._trace("'\\t'", (14, 18), self.input.position)
                 _G_exactly_4, lastError = self.exactly('\t')
                 self.considerError(lastError, None)
                 return (_G_exactly_4, self.currentError)
             def _G_or_5():
+                self._trace("'\\f'", (19, 23), self.input.position)
                 _G_exactly_6, lastError = self.exactly('\x0c')
                 self.considerError(lastError, None)
                 return (_G_exactly_6, self.currentError)
             def _G_or_7():
+                self._trace("'#'", (25, 28), self.input.position)
                 _G_exactly_8, lastError = self.exactly('#')
                 self.considerError(lastError, None)
                 def _G_many_9():
                     def _G_not_10():
+                        self._trace('eol', (31, 34), self.input.position)
                         _G_apply_11, lastError = self._apply(self.rule_eol, "eol", [])
                         self.considerError(lastError, None)
                         return (_G_apply_11, self.currentError)
                     _G_not_12, lastError = self._not(_G_not_10)
                     self.considerError(lastError, None)
+                    self._trace(' anything', (34, 43), self.input.position)
                     _G_apply_13, lastError = self._apply(self.rule_anything, "anything", [])
                     self.considerError(lastError, None)
                     return (_G_apply_13, self.currentError)
@@ -43,20 +49,25 @@ def createParserClass(GrammarBase, ruleGlobals):
             self.locals['ws'] = _locals
             def _G_many_16():
                 def _G_or_17():
+                    self._trace("'\\r'", (54, 58), self.input.position)
                     _G_exactly_18, lastError = self.exactly('\r')
                     self.considerError(lastError, None)
+                    self._trace(" '\\n'", (58, 63), self.input.position)
                     _G_exactly_19, lastError = self.exactly('\n')
                     self.considerError(lastError, None)
                     return (_G_exactly_19, self.currentError)
                 def _G_or_20():
+                    self._trace("'\\r'", (64, 68), self.input.position)
                     _G_exactly_21, lastError = self.exactly('\r')
                     self.considerError(lastError, None)
                     return (_G_exactly_21, self.currentError)
                 def _G_or_22():
+                    self._trace(" '\\n'", (70, 75), self.input.position)
                     _G_exactly_23, lastError = self.exactly('\n')
                     self.considerError(lastError, None)
                     return (_G_exactly_23, self.currentError)
                 def _G_or_24():
+                    self._trace(' hspace', (77, 84), self.input.position)
                     _G_apply_25, lastError = self._apply(self.rule_hspace, "hspace", [])
                     self.considerError(lastError, None)
                     return (_G_apply_25, self.currentError)
@@ -71,8 +82,10 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_number(self):
             _locals = {'self': self}
             self.locals['number'] = _locals
+            self._trace(' ws', (96, 99), self.input.position)
             _G_apply_28, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'number')
+            self._trace(' barenumber', (99, 110), self.input.position)
             _G_apply_29, lastError = self._apply(self.rule_barenumber, "barenumber", [])
             self.considerError(lastError, 'number')
             return (_G_apply_29, self.currentError)
@@ -82,6 +95,7 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['barenumber'] = _locals
             def _G_optional_30():
+                self._trace(" '-'", (123, 127), self.input.position)
                 _G_exactly_31, lastError = self.exactly('-')
                 self.considerError(lastError, None)
                 return (_G_exactly_31, self.currentError)
@@ -91,20 +105,24 @@ def createParserClass(GrammarBase, ruleGlobals):
             self.considerError(lastError, 'barenumber')
             _locals['sign'] = _G_or_33
             def _G_or_34():
+                self._trace("'0'", (136, 139), self.input.position)
                 _G_exactly_35, lastError = self.exactly('0')
                 self.considerError(lastError, None)
                 def _G_or_36():
                     def _G_or_37():
+                        self._trace("'x'", (143, 146), self.input.position)
                         _G_exactly_38, lastError = self.exactly('x')
                         self.considerError(lastError, None)
                         return (_G_exactly_38, self.currentError)
                     def _G_or_39():
+                        self._trace("'X'", (147, 150), self.input.position)
                         _G_exactly_40, lastError = self.exactly('X')
                         self.considerError(lastError, None)
                         return (_G_exactly_40, self.currentError)
                     _G_or_41, lastError = self._or([_G_or_37, _G_or_39])
                     self.considerError(lastError, None)
                     def _G_many_42():
+                        self._trace(' hexdigit', (151, 160), self.input.position)
                         _G_apply_43, lastError = self._apply(self.rule_hexdigit, "hexdigit", [])
                         self.considerError(lastError, None)
                         return (_G_apply_43, self.currentError)
@@ -115,15 +133,17 @@ def createParserClass(GrammarBase, ruleGlobals):
                     self.considerError(lastError, None)
                     return (_G_python_45, self.currentError)
                 def _G_or_46():
+                    self._trace("floatPart(sign '0')", (208, 227), self.input.position)
                     _G_python_47, lastError = eval('sign', self.globals, _locals), None
                     self.considerError(lastError, None)
-                    _G_python_48, lastError = '0', None
+                    _G_python_48, lastError = ('0'), None
                     self.considerError(lastError, None)
                     _G_apply_49, lastError = self._apply(self.rule_floatPart, "floatPart", [_G_python_47, _G_python_48])
                     self.considerError(lastError, None)
                     return (_G_apply_49, self.currentError)
                 def _G_or_50():
                     def _G_many_51():
+                        self._trace('octaldigit', (249, 259), self.input.position)
                         _G_apply_52, lastError = self._apply(self.rule_octaldigit, "octaldigit", [])
                         self.considerError(lastError, None)
                         return (_G_apply_52, self.currentError)
@@ -137,9 +157,11 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self.considerError(lastError, None)
                 return (_G_or_55, self.currentError)
             def _G_or_56():
+                self._trace('decdigits', (305, 314), self.input.position)
                 _G_apply_57, lastError = self._apply(self.rule_decdigits, "decdigits", [])
                 self.considerError(lastError, None)
                 _locals['ds'] = _G_apply_57
+                self._trace(' floatPart(sign ds)', (317, 336), self.input.position)
                 _G_python_58, lastError = eval('sign', self.globals, _locals), None
                 self.considerError(lastError, None)
                 _G_python_59, lastError = eval('ds', self.globals, _locals), None
@@ -148,6 +170,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self.considerError(lastError, None)
                 return (_G_apply_60, self.currentError)
             def _G_or_61():
+                self._trace('decdigits', (353, 362), self.input.position)
                 _G_apply_62, lastError = self._apply(self.rule_decdigits, "decdigits", [])
                 self.considerError(lastError, None)
                 _locals['ds'] = _G_apply_62
@@ -164,10 +187,12 @@ def createParserClass(GrammarBase, ruleGlobals):
             self.locals['exponent'] = _locals
             def _G_consumedby_65():
                 def _G_or_66():
+                    self._trace("'e'", (405, 408), self.input.position)
                     _G_exactly_67, lastError = self.exactly('e')
                     self.considerError(lastError, None)
                     return (_G_exactly_67, self.currentError)
                 def _G_or_68():
+                    self._trace(" 'E'", (410, 414), self.input.position)
                     _G_exactly_69, lastError = self.exactly('E')
                     self.considerError(lastError, None)
                     return (_G_exactly_69, self.currentError)
@@ -175,10 +200,12 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self.considerError(lastError, None)
                 def _G_optional_71():
                     def _G_or_72():
+                        self._trace("'+'", (417, 420), self.input.position)
                         _G_exactly_73, lastError = self.exactly('+')
                         self.considerError(lastError, None)
                         return (_G_exactly_73, self.currentError)
                     def _G_or_74():
+                        self._trace(" '-'", (422, 426), self.input.position)
                         _G_exactly_75, lastError = self.exactly('-')
                         self.considerError(lastError, None)
                         return (_G_exactly_75, self.currentError)
@@ -189,6 +216,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                     return (None, self.input.nullError())
                 _G_or_78, lastError = self._or([_G_optional_71, _G_optional_77])
                 self.considerError(lastError, None)
+                self._trace(' decdigits', (428, 438), self.input.position)
                 _G_apply_79, lastError = self._apply(self.rule_decdigits, "decdigits", [])
                 self.considerError(lastError, None)
                 return (_G_apply_79, self.currentError)
@@ -208,11 +236,14 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals['ds'] = _G_apply_82
             def _G_consumedby_83():
                 def _G_or_84():
+                    self._trace("'.'", (466, 469), self.input.position)
                     _G_exactly_85, lastError = self.exactly('.')
                     self.considerError(lastError, None)
+                    self._trace(' decdigits', (469, 479), self.input.position)
                     _G_apply_86, lastError = self._apply(self.rule_decdigits, "decdigits", [])
                     self.considerError(lastError, None)
                     def _G_optional_87():
+                        self._trace(' exponent', (479, 488), self.input.position)
                         _G_apply_88, lastError = self._apply(self.rule_exponent, "exponent", [])
                         self.considerError(lastError, None)
                         return (_G_apply_88, self.currentError)
@@ -222,6 +253,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                     self.considerError(lastError, None)
                     return (_G_or_90, self.currentError)
                 def _G_or_91():
+                    self._trace(' exponent', (492, 501), self.input.position)
                     _G_apply_92, lastError = self._apply(self.rule_exponent, "exponent", [])
                     self.considerError(lastError, None)
                     return (_G_apply_92, self.currentError)
@@ -239,6 +271,7 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_decdigits(self):
             _locals = {'self': self}
             self.locals['decdigits'] = _locals
+            self._trace(' digit', (549, 555), self.input.position)
             _G_apply_96, lastError = self._apply(self.rule_digit, "digit", [])
             self.considerError(lastError, 'decdigits')
             _locals['d'] = _G_apply_96
@@ -257,9 +290,10 @@ def createParserClass(GrammarBase, ruleGlobals):
                     self.considerError(lastError, None)
                     return (_G_python_103, self.currentError)
                 def _G_or_104():
+                    self._trace(" '_'", (584, 588), self.input.position)
                     _G_exactly_105, lastError = self.exactly('_')
                     self.considerError(lastError, None)
-                    _G_python_106, lastError = "", None
+                    _G_python_106, lastError = (""), None
                     self.considerError(lastError, None)
                     return (_G_python_106, self.currentError)
                 _G_or_107, lastError = self._or([_G_or_98, _G_or_104])
@@ -310,22 +344,27 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_string(self):
             _locals = {'self': self}
             self.locals['string'] = _locals
+            self._trace(' ws', (706, 709), self.input.position)
             _G_apply_120, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'string')
+            self._trace(' \'"\'', (709, 713), self.input.position)
             _G_exactly_121, lastError = self.exactly('"')
             self.considerError(lastError, 'string')
             def _G_many_122():
                 def _G_or_123():
+                    self._trace('escapedChar', (715, 726), self.input.position)
                     _G_apply_124, lastError = self._apply(self.rule_escapedChar, "escapedChar", [])
                     self.considerError(lastError, None)
                     return (_G_apply_124, self.currentError)
                 def _G_or_125():
                     def _G_not_126():
+                        self._trace('\'"\'', (731, 734), self.input.position)
                         _G_exactly_127, lastError = self.exactly('"')
                         self.considerError(lastError, None)
                         return (_G_exactly_127, self.currentError)
                     _G_not_128, lastError = self._not(_G_not_126)
                     self.considerError(lastError, None)
+                    self._trace(' anything', (735, 744), self.input.position)
                     _G_apply_129, lastError = self._apply(self.rule_anything, "anything", [])
                     self.considerError(lastError, None)
                     return (_G_apply_129, self.currentError)
@@ -335,6 +374,7 @@ def createParserClass(GrammarBase, ruleGlobals):
             _G_many_131, lastError = self.many(_G_many_122)
             self.considerError(lastError, 'string')
             _locals['c'] = _G_many_131
+            self._trace(' \'"\'', (748, 752), self.input.position)
             _G_exactly_132, lastError = self.exactly('"')
             self.considerError(lastError, 'string')
             _G_python_133, lastError = eval('join(c)', self.globals, _locals), None
@@ -345,29 +385,36 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_character(self):
             _locals = {'self': self}
             self.locals['character'] = _locals
+            self._trace(' ws', (775, 778), self.input.position)
             _G_apply_134, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'character')
+            self._trace(" '\\''", (778, 783), self.input.position)
             _G_exactly_135, lastError = self.exactly("'")
             self.considerError(lastError, 'character')
             def _G_or_136():
+                self._trace('escapedChar', (785, 796), self.input.position)
                 _G_apply_137, lastError = self._apply(self.rule_escapedChar, "escapedChar", [])
                 self.considerError(lastError, None)
                 return (_G_apply_137, self.currentError)
             def _G_or_138():
                 def _G_not_139():
                     def _G_or_140():
+                        self._trace("'\\''", (801, 805), self.input.position)
                         _G_exactly_141, lastError = self.exactly("'")
                         self.considerError(lastError, None)
                         return (_G_exactly_141, self.currentError)
                     def _G_or_142():
+                        self._trace("'\\n'", (806, 810), self.input.position)
                         _G_exactly_143, lastError = self.exactly('\n')
                         self.considerError(lastError, None)
                         return (_G_exactly_143, self.currentError)
                     def _G_or_144():
+                        self._trace("'\\r'", (811, 815), self.input.position)
                         _G_exactly_145, lastError = self.exactly('\r')
                         self.considerError(lastError, None)
                         return (_G_exactly_145, self.currentError)
                     def _G_or_146():
+                        self._trace("'\\\\'", (816, 820), self.input.position)
                         _G_exactly_147, lastError = self.exactly('\\')
                         self.considerError(lastError, None)
                         return (_G_exactly_147, self.currentError)
@@ -376,12 +423,14 @@ def createParserClass(GrammarBase, ruleGlobals):
                     return (_G_or_148, self.currentError)
                 _G_not_149, lastError = self._not(_G_not_139)
                 self.considerError(lastError, None)
+                self._trace(' anything', (821, 830), self.input.position)
                 _G_apply_150, lastError = self._apply(self.rule_anything, "anything", [])
                 self.considerError(lastError, None)
                 return (_G_apply_150, self.currentError)
             _G_or_151, lastError = self._or([_G_or_136, _G_or_138])
             self.considerError(lastError, 'character')
             _locals['c'] = _G_or_151
+            self._trace(" '\\''", (833, 838), self.input.position)
             _G_exactly_152, lastError = self.exactly("'")
             self.considerError(lastError, 'character')
             _G_python_153, lastError = eval('Character(c)', self.globals, _locals), None
@@ -393,15 +442,20 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['escapedUnicode'] = _locals
             def _G_or_154():
+                self._trace("'u'", (873, 876), self.input.position)
                 _G_exactly_155, lastError = self.exactly('u')
                 self.considerError(lastError, None)
                 def _G_consumedby_156():
+                    self._trace('hexdigit', (878, 886), self.input.position)
                     _G_apply_157, lastError = self._apply(self.rule_hexdigit, "hexdigit", [])
                     self.considerError(lastError, None)
+                    self._trace(' hexdigit', (886, 895), self.input.position)
                     _G_apply_158, lastError = self._apply(self.rule_hexdigit, "hexdigit", [])
                     self.considerError(lastError, None)
+                    self._trace(' hexdigit', (895, 904), self.input.position)
                     _G_apply_159, lastError = self._apply(self.rule_hexdigit, "hexdigit", [])
                     self.considerError(lastError, None)
+                    self._trace(' hexdigit', (904, 913), self.input.position)
                     _G_apply_160, lastError = self._apply(self.rule_hexdigit, "hexdigit", [])
                     self.considerError(lastError, None)
                     return (_G_apply_160, self.currentError)
@@ -412,23 +466,32 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self.considerError(lastError, None)
                 return (_G_python_162, self.currentError)
             def _G_or_163():
+                self._trace("'U'", (961, 964), self.input.position)
                 _G_exactly_164, lastError = self.exactly('U')
                 self.considerError(lastError, None)
                 def _G_consumedby_165():
+                    self._trace('hexdigit', (966, 974), self.input.position)
                     _G_apply_166, lastError = self._apply(self.rule_hexdigit, "hexdigit", [])
                     self.considerError(lastError, None)
+                    self._trace(' hexdigit', (974, 983), self.input.position)
                     _G_apply_167, lastError = self._apply(self.rule_hexdigit, "hexdigit", [])
                     self.considerError(lastError, None)
+                    self._trace(' hexdigit', (983, 992), self.input.position)
                     _G_apply_168, lastError = self._apply(self.rule_hexdigit, "hexdigit", [])
                     self.considerError(lastError, None)
+                    self._trace(' hexdigit', (992, 1001), self.input.position)
                     _G_apply_169, lastError = self._apply(self.rule_hexdigit, "hexdigit", [])
                     self.considerError(lastError, None)
+                    self._trace('\n                         hexdigit', (1001, 1035), self.input.position)
                     _G_apply_170, lastError = self._apply(self.rule_hexdigit, "hexdigit", [])
                     self.considerError(lastError, None)
+                    self._trace(' hexdigit', (1035, 1044), self.input.position)
                     _G_apply_171, lastError = self._apply(self.rule_hexdigit, "hexdigit", [])
                     self.considerError(lastError, None)
+                    self._trace(' hexdigit', (1044, 1053), self.input.position)
                     _G_apply_172, lastError = self._apply(self.rule_hexdigit, "hexdigit", [])
                     self.considerError(lastError, None)
+                    self._trace(' hexdigit', (1053, 1062), self.input.position)
                     _G_apply_173, lastError = self._apply(self.rule_hexdigit, "hexdigit", [])
                     self.considerError(lastError, None)
                     return (_G_apply_173, self.currentError)
@@ -458,6 +521,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                     _G_pred_182, lastError = self.pred(_G_pred_180)
                     self.considerError(lastError, None)
                     def _G_optional_183():
+                        self._trace(' octdigit', (1135, 1144), self.input.position)
                         _G_apply_184, lastError = self._apply(self.rule_octdigit, "octdigit", [])
                         self.considerError(lastError, None)
                         return (_G_apply_184, self.currentError)
@@ -466,6 +530,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                     _G_or_186, lastError = self._or([_G_optional_183, _G_optional_185])
                     self.considerError(lastError, None)
                     def _G_optional_187():
+                        self._trace(' octdigit', (1145, 1154), self.input.position)
                         _G_apply_188, lastError = self._apply(self.rule_octdigit, "octdigit", [])
                         self.considerError(lastError, None)
                         return (_G_apply_188, self.currentError)
@@ -489,6 +554,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                     _G_pred_197, lastError = self.pred(_G_pred_195)
                     self.considerError(lastError, None)
                     def _G_optional_198():
+                        self._trace(' octdigit', (1202, 1211), self.input.position)
                         _G_apply_199, lastError = self._apply(self.rule_octdigit, "octdigit", [])
                         self.considerError(lastError, None)
                         return (_G_apply_199, self.currentError)
@@ -511,74 +577,87 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_escapedChar(self):
             _locals = {'self': self}
             self.locals['escapedChar'] = _locals
+            self._trace(" '\\\\'", (1246, 1251), self.input.position)
             _G_exactly_205, lastError = self.exactly('\\')
             self.considerError(lastError, 'escapedChar')
             def _G_or_206():
+                self._trace("'n'", (1253, 1256), self.input.position)
                 _G_exactly_207, lastError = self.exactly('n')
                 self.considerError(lastError, None)
-                _G_python_208, lastError = '\n', None
+                _G_python_208, lastError = ('\n'), None
                 self.considerError(lastError, None)
                 return (_G_python_208, self.currentError)
             def _G_or_209():
+                self._trace("'r'", (1287, 1290), self.input.position)
                 _G_exactly_210, lastError = self.exactly('r')
                 self.considerError(lastError, None)
-                _G_python_211, lastError = '\r', None
+                _G_python_211, lastError = ('\r'), None
                 self.considerError(lastError, None)
                 return (_G_python_211, self.currentError)
             def _G_or_212():
+                self._trace("'t'", (1321, 1324), self.input.position)
                 _G_exactly_213, lastError = self.exactly('t')
                 self.considerError(lastError, None)
-                _G_python_214, lastError = '\t', None
+                _G_python_214, lastError = ('\t'), None
                 self.considerError(lastError, None)
                 return (_G_python_214, self.currentError)
             def _G_or_215():
+                self._trace("'b'", (1355, 1358), self.input.position)
                 _G_exactly_216, lastError = self.exactly('b')
                 self.considerError(lastError, None)
-                _G_python_217, lastError = '\b', None
+                _G_python_217, lastError = ('\b'), None
                 self.considerError(lastError, None)
                 return (_G_python_217, self.currentError)
             def _G_or_218():
+                self._trace("'f'", (1389, 1392), self.input.position)
                 _G_exactly_219, lastError = self.exactly('f')
                 self.considerError(lastError, None)
-                _G_python_220, lastError = '\f', None
+                _G_python_220, lastError = ('\f'), None
                 self.considerError(lastError, None)
                 return (_G_python_220, self.currentError)
             def _G_or_221():
+                self._trace('\'"\'', (1423, 1426), self.input.position)
                 _G_exactly_222, lastError = self.exactly('"')
                 self.considerError(lastError, None)
-                _G_python_223, lastError = '"', None
+                _G_python_223, lastError = ('"'), None
                 self.considerError(lastError, None)
                 return (_G_python_223, self.currentError)
             def _G_or_224():
+                self._trace("'\\''", (1456, 1460), self.input.position)
                 _G_exactly_225, lastError = self.exactly("'")
                 self.considerError(lastError, None)
-                _G_python_226, lastError = '\'', None
+                _G_python_226, lastError = ('\''), None
                 self.considerError(lastError, None)
                 return (_G_python_226, self.currentError)
             def _G_or_227():
+                self._trace("'?'", (1491, 1494), self.input.position)
                 _G_exactly_228, lastError = self.exactly('?')
                 self.considerError(lastError, None)
-                _G_python_229, lastError = '?', None
+                _G_python_229, lastError = ('?'), None
                 self.considerError(lastError, None)
                 return (_G_python_229, self.currentError)
             def _G_or_230():
+                self._trace("'\\\\'", (1524, 1528), self.input.position)
                 _G_exactly_231, lastError = self.exactly('\\')
                 self.considerError(lastError, None)
-                _G_python_232, lastError = '\\', None
+                _G_python_232, lastError = ('\\'), None
                 self.considerError(lastError, None)
                 return (_G_python_232, self.currentError)
             def _G_or_233():
+                self._trace(' escapedUnicode', (1559, 1574), self.input.position)
                 _G_apply_234, lastError = self._apply(self.rule_escapedUnicode, "escapedUnicode", [])
                 self.considerError(lastError, None)
                 return (_G_apply_234, self.currentError)
             def _G_or_235():
+                self._trace(' escapedOctal', (1597, 1610), self.input.position)
                 _G_apply_236, lastError = self._apply(self.rule_escapedOctal, "escapedOctal", [])
                 self.considerError(lastError, None)
                 return (_G_apply_236, self.currentError)
             def _G_or_237():
+                self._trace(' eol', (1633, 1637), self.input.position)
                 _G_apply_238, lastError = self._apply(self.rule_eol, "eol", [])
                 self.considerError(lastError, None)
-                _G_python_239, lastError = "", None
+                _G_python_239, lastError = (""), None
                 self.considerError(lastError, None)
                 return (_G_python_239, self.currentError)
             _G_or_240, lastError = self._or([_G_or_206, _G_or_209, _G_or_212, _G_or_215, _G_or_218, _G_or_221, _G_or_224, _G_or_227, _G_or_230, _G_or_233, _G_or_235, _G_or_237])
@@ -590,22 +669,27 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['eol'] = _locals
             def _G_many_241():
+                self._trace(' hspace', (1651, 1658), self.input.position)
                 _G_apply_242, lastError = self._apply(self.rule_hspace, "hspace", [])
                 self.considerError(lastError, None)
                 return (_G_apply_242, self.currentError)
             _G_many_243, lastError = self.many(_G_many_241)
             self.considerError(lastError, 'eol')
             def _G_or_244():
+                self._trace("'\\r'", (1661, 1665), self.input.position)
                 _G_exactly_245, lastError = self.exactly('\r')
                 self.considerError(lastError, None)
+                self._trace(" '\\n'", (1665, 1670), self.input.position)
                 _G_exactly_246, lastError = self.exactly('\n')
                 self.considerError(lastError, None)
                 return (_G_exactly_246, self.currentError)
             def _G_or_247():
+                self._trace("'\\r'", (1671, 1675), self.input.position)
                 _G_exactly_248, lastError = self.exactly('\r')
                 self.considerError(lastError, None)
                 return (_G_exactly_248, self.currentError)
             def _G_or_249():
+                self._trace(" '\\n'", (1677, 1682), self.input.position)
                 _G_exactly_250, lastError = self.exactly('\n')
                 self.considerError(lastError, None)
                 return (_G_exactly_250, self.currentError)
@@ -620,98 +704,122 @@ def createParserClass(GrammarBase, ruleGlobals):
             def _G_consumedby_252():
                 def _G_many1_253():
                     def _G_or_254():
+                        self._trace('letterOrDigit', (1697, 1710), self.input.position)
                         _G_apply_255, lastError = self._apply(self.rule_letterOrDigit, "letterOrDigit", [])
                         self.considerError(lastError, None)
                         return (_G_apply_255, self.currentError)
                     def _G_or_256():
+                        self._trace("'_'", (1711, 1714), self.input.position)
                         _G_exactly_257, lastError = self.exactly('_')
                         self.considerError(lastError, None)
                         return (_G_exactly_257, self.currentError)
                     def _G_or_258():
+                        self._trace("';'", (1715, 1718), self.input.position)
                         _G_exactly_259, lastError = self.exactly(';')
                         self.considerError(lastError, None)
                         return (_G_exactly_259, self.currentError)
                     def _G_or_260():
+                        self._trace("'/'", (1719, 1722), self.input.position)
                         _G_exactly_261, lastError = self.exactly('/')
                         self.considerError(lastError, None)
                         return (_G_exactly_261, self.currentError)
                     def _G_or_262():
+                        self._trace("'?'", (1723, 1726), self.input.position)
                         _G_exactly_263, lastError = self.exactly('?')
                         self.considerError(lastError, None)
                         return (_G_exactly_263, self.currentError)
                     def _G_or_264():
+                        self._trace("':'", (1727, 1730), self.input.position)
                         _G_exactly_265, lastError = self.exactly(':')
                         self.considerError(lastError, None)
                         return (_G_exactly_265, self.currentError)
                     def _G_or_266():
+                        self._trace("'@'", (1731, 1734), self.input.position)
                         _G_exactly_267, lastError = self.exactly('@')
                         self.considerError(lastError, None)
                         return (_G_exactly_267, self.currentError)
                     def _G_or_268():
+                        self._trace("'&'", (1735, 1738), self.input.position)
                         _G_exactly_269, lastError = self.exactly('&')
                         self.considerError(lastError, None)
                         return (_G_exactly_269, self.currentError)
                     def _G_or_270():
+                        self._trace("'='", (1739, 1742), self.input.position)
                         _G_exactly_271, lastError = self.exactly('=')
                         self.considerError(lastError, None)
                         return (_G_exactly_271, self.currentError)
                     def _G_or_272():
+                        self._trace("'+'", (1743, 1746), self.input.position)
                         _G_exactly_273, lastError = self.exactly('+')
                         self.considerError(lastError, None)
                         return (_G_exactly_273, self.currentError)
                     def _G_or_274():
+                        self._trace("'$'", (1747, 1750), self.input.position)
                         _G_exactly_275, lastError = self.exactly('$')
                         self.considerError(lastError, None)
                         return (_G_exactly_275, self.currentError)
                     def _G_or_276():
+                        self._trace("','", (1751, 1754), self.input.position)
                         _G_exactly_277, lastError = self.exactly(',')
                         self.considerError(lastError, None)
                         return (_G_exactly_277, self.currentError)
                     def _G_or_278():
+                        self._trace("'-'", (1755, 1758), self.input.position)
                         _G_exactly_279, lastError = self.exactly('-')
                         self.considerError(lastError, None)
                         return (_G_exactly_279, self.currentError)
                     def _G_or_280():
+                        self._trace("'.'", (1759, 1762), self.input.position)
                         _G_exactly_281, lastError = self.exactly('.')
                         self.considerError(lastError, None)
                         return (_G_exactly_281, self.currentError)
                     def _G_or_282():
+                        self._trace("'!'", (1763, 1766), self.input.position)
                         _G_exactly_283, lastError = self.exactly('!')
                         self.considerError(lastError, None)
                         return (_G_exactly_283, self.currentError)
                     def _G_or_284():
+                        self._trace("'~'", (1767, 1770), self.input.position)
                         _G_exactly_285, lastError = self.exactly('~')
                         self.considerError(lastError, None)
                         return (_G_exactly_285, self.currentError)
                     def _G_or_286():
+                        self._trace("'*'", (1771, 1774), self.input.position)
                         _G_exactly_287, lastError = self.exactly('*')
                         self.considerError(lastError, None)
                         return (_G_exactly_287, self.currentError)
                     def _G_or_288():
+                        self._trace("'\\''", (1775, 1779), self.input.position)
                         _G_exactly_289, lastError = self.exactly("'")
                         self.considerError(lastError, None)
                         return (_G_exactly_289, self.currentError)
                     def _G_or_290():
+                        self._trace("'('", (1780, 1783), self.input.position)
                         _G_exactly_291, lastError = self.exactly('(')
                         self.considerError(lastError, None)
                         return (_G_exactly_291, self.currentError)
                     def _G_or_292():
+                        self._trace("')'", (1784, 1787), self.input.position)
                         _G_exactly_293, lastError = self.exactly(')')
                         self.considerError(lastError, None)
                         return (_G_exactly_293, self.currentError)
                     def _G_or_294():
+                        self._trace("'%'", (1788, 1791), self.input.position)
                         _G_exactly_295, lastError = self.exactly('%')
                         self.considerError(lastError, None)
                         return (_G_exactly_295, self.currentError)
                     def _G_or_296():
+                        self._trace("'\\\\'", (1792, 1796), self.input.position)
                         _G_exactly_297, lastError = self.exactly('\\')
                         self.considerError(lastError, None)
                         return (_G_exactly_297, self.currentError)
                     def _G_or_298():
+                        self._trace("'|'", (1797, 1800), self.input.position)
                         _G_exactly_299, lastError = self.exactly('|')
                         self.considerError(lastError, None)
                         return (_G_exactly_299, self.currentError)
                     def _G_or_300():
+                        self._trace("'#'", (1801, 1804), self.input.position)
                         _G_exactly_301, lastError = self.exactly('#')
                         self.considerError(lastError, None)
                         return (_G_exactly_301, self.currentError)
@@ -730,6 +838,7 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['literal'] = _locals
             def _G_or_305():
+                self._trace(' string', (1819, 1826), self.input.position)
                 _G_apply_306, lastError = self._apply(self.rule_string, "string", [])
                 self.considerError(lastError, None)
                 _locals['x'] = _G_apply_306
@@ -737,6 +846,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self.considerError(lastError, None)
                 return (_G_python_307, self.currentError)
             def _G_or_308():
+                self._trace(' character', (1874, 1884), self.input.position)
                 _G_apply_309, lastError = self._apply(self.rule_character, "character", [])
                 self.considerError(lastError, None)
                 _locals['x'] = _G_apply_309
@@ -744,6 +854,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self.considerError(lastError, None)
                 return (_G_python_310, self.currentError)
             def _G_or_311():
+                self._trace(' number', (1930, 1937), self.input.position)
                 _G_apply_312, lastError = self._apply(self.rule_number, "number", [])
                 self.considerError(lastError, None)
                 _locals['x'] = _G_apply_312
@@ -759,14 +870,18 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['tag'] = _locals
             def _G_or_315():
+                self._trace('\n          segment', (1988, 2006), self.input.position)
                 _G_apply_316, lastError = self._apply(self.rule_segment, "segment", [])
                 self.considerError(lastError, None)
                 _locals['seg1'] = _G_apply_316
                 def _G_many_317():
+                    self._trace("':'", (2013, 2016), self.input.position)
                     _G_exactly_318, lastError = self.exactly(':')
                     self.considerError(lastError, None)
+                    self._trace(" ':'", (2016, 2020), self.input.position)
                     _G_exactly_319, lastError = self.exactly(':')
                     self.considerError(lastError, None)
+                    self._trace(' sos', (2020, 2024), self.input.position)
                     _G_apply_320, lastError = self._apply(self.rule_sos, "sos", [])
                     self.considerError(lastError, None)
                     return (_G_apply_320, self.currentError)
@@ -778,10 +893,13 @@ def createParserClass(GrammarBase, ruleGlobals):
                 return (_G_python_322, self.currentError)
             def _G_or_323():
                 def _G_many1_324():
+                    self._trace("':'", (2072, 2075), self.input.position)
                     _G_exactly_325, lastError = self.exactly(':')
                     self.considerError(lastError, None)
+                    self._trace(" ':'", (2075, 2079), self.input.position)
                     _G_exactly_326, lastError = self.exactly(':')
                     self.considerError(lastError, None)
+                    self._trace(' sos', (2079, 2083), self.input.position)
                     _G_apply_327, lastError = self._apply(self.rule_sos, "sos", [])
                     self.considerError(lastError, None)
                     return (_G_apply_327, self.currentError)
@@ -800,10 +918,12 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['sos'] = _locals
             def _G_or_331():
+                self._trace(' segment', (2119, 2127), self.input.position)
                 _G_apply_332, lastError = self._apply(self.rule_segment, "segment", [])
                 self.considerError(lastError, None)
                 return (_G_apply_332, self.currentError)
             def _G_or_333():
+                self._trace('string', (2131, 2137), self.input.position)
                 _G_apply_334, lastError = self._apply(self.rule_string, "string", [])
                 self.considerError(lastError, None)
                 _locals['s'] = _G_apply_334
@@ -819,14 +939,17 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['segment'] = _locals
             def _G_or_337():
+                self._trace(' ident', (2167, 2173), self.input.position)
                 _G_apply_338, lastError = self._apply(self.rule_ident, "ident", [])
                 self.considerError(lastError, None)
                 return (_G_apply_338, self.currentError)
             def _G_or_339():
+                self._trace(' special', (2175, 2183), self.input.position)
                 _G_apply_340, lastError = self._apply(self.rule_special, "special", [])
                 self.considerError(lastError, None)
                 return (_G_apply_340, self.currentError)
             def _G_or_341():
+                self._trace(' uri', (2185, 2189), self.input.position)
                 _G_apply_342, lastError = self._apply(self.rule_uri, "uri", [])
                 self.considerError(lastError, None)
                 return (_G_apply_342, self.currentError)
@@ -838,10 +961,12 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_ident(self):
             _locals = {'self': self}
             self.locals['ident'] = _locals
+            self._trace(' segStart', (2198, 2207), self.input.position)
             _G_apply_344, lastError = self._apply(self.rule_segStart, "segStart", [])
             self.considerError(lastError, 'ident')
             _locals['i1'] = _G_apply_344
             def _G_many_345():
+                self._trace(' segPart', (2210, 2218), self.input.position)
                 _G_apply_346, lastError = self._apply(self.rule_segPart, "segPart", [])
                 self.considerError(lastError, None)
                 return (_G_apply_346, self.currentError)
@@ -857,14 +982,17 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['segStart'] = _locals
             def _G_or_349():
+                self._trace(' letter', (2262, 2269), self.input.position)
                 _G_apply_350, lastError = self._apply(self.rule_letter, "letter", [])
                 self.considerError(lastError, None)
                 return (_G_apply_350, self.currentError)
             def _G_or_351():
+                self._trace(" '_'", (2271, 2275), self.input.position)
                 _G_exactly_352, lastError = self.exactly('_')
                 self.considerError(lastError, None)
                 return (_G_exactly_352, self.currentError)
             def _G_or_353():
+                self._trace(" '$'", (2277, 2281), self.input.position)
                 _G_exactly_354, lastError = self.exactly('$')
                 self.considerError(lastError, None)
                 return (_G_exactly_354, self.currentError)
@@ -877,22 +1005,27 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['segPart'] = _locals
             def _G_or_356():
+                self._trace(' letterOrDigit', (2292, 2306), self.input.position)
                 _G_apply_357, lastError = self._apply(self.rule_letterOrDigit, "letterOrDigit", [])
                 self.considerError(lastError, None)
                 return (_G_apply_357, self.currentError)
             def _G_or_358():
+                self._trace(" '_'", (2308, 2312), self.input.position)
                 _G_exactly_359, lastError = self.exactly('_')
                 self.considerError(lastError, None)
                 return (_G_exactly_359, self.currentError)
             def _G_or_360():
+                self._trace(" '.'", (2314, 2318), self.input.position)
                 _G_exactly_361, lastError = self.exactly('.')
                 self.considerError(lastError, None)
                 return (_G_exactly_361, self.currentError)
             def _G_or_362():
+                self._trace(" '-'", (2320, 2324), self.input.position)
                 _G_exactly_363, lastError = self.exactly('-')
                 self.considerError(lastError, None)
                 return (_G_exactly_363, self.currentError)
             def _G_or_364():
+                self._trace(" '$'", (2326, 2330), self.input.position)
                 _G_exactly_365, lastError = self.exactly('$')
                 self.considerError(lastError, None)
                 return (_G_exactly_365, self.currentError)
@@ -904,9 +1037,11 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_special(self):
             _locals = {'self': self}
             self.locals['special'] = _locals
+            self._trace(" '.'", (2341, 2345), self.input.position)
             _G_exactly_367, lastError = self.exactly('.')
             self.considerError(lastError, 'special')
             _locals['a'] = _G_exactly_367
+            self._trace(' ident', (2347, 2353), self.input.position)
             _G_apply_368, lastError = self._apply(self.rule_ident, "ident", [])
             self.considerError(lastError, 'special')
             _locals['b'] = _G_apply_368
@@ -918,15 +1053,18 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_uri(self):
             _locals = {'self': self}
             self.locals['uri'] = _locals
+            self._trace(" '<'", (2378, 2382), self.input.position)
             _G_exactly_370, lastError = self.exactly('<')
             self.considerError(lastError, 'uri')
             def _G_many_371():
+                self._trace(' uriBody', (2382, 2390), self.input.position)
                 _G_apply_372, lastError = self._apply(self.rule_uriBody, "uriBody", [])
                 self.considerError(lastError, None)
                 return (_G_apply_372, self.currentError)
             _G_many_373, lastError = self.many(_G_many_371)
             self.considerError(lastError, 'uri')
             _locals['uriChars'] = _G_many_373
+            self._trace(" '>'", (2400, 2404), self.input.position)
             _G_exactly_374, lastError = self.exactly('>')
             self.considerError(lastError, 'uri')
             _G_python_375, lastError = eval('concat(b, uriChars, e)', self.globals, _locals), None
@@ -937,13 +1075,16 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_functor(self):
             _locals = {'self': self}
             self.locals['functor'] = _locals
+            self._trace(' ws', (2441, 2444), self.input.position)
             _G_apply_376, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'functor')
             def _G_or_377():
+                self._trace('literal', (2446, 2453), self.input.position)
                 _G_apply_378, lastError = self._apply(self.rule_literal, "literal", [])
                 self.considerError(lastError, None)
                 return (_G_apply_378, self.currentError)
             def _G_or_379():
+                self._trace(' tag', (2455, 2459), self.input.position)
                 _G_apply_380, lastError = self._apply(self.rule_tag, "tag", [])
                 self.considerError(lastError, None)
                 _locals['t'] = _G_apply_380
@@ -958,17 +1099,22 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_baseTerm(self):
             _locals = {'self': self}
             self.locals['baseTerm'] = _locals
+            self._trace(' functor', (2498, 2506), self.input.position)
             _G_apply_383, lastError = self._apply(self.rule_functor, "functor", [])
             self.considerError(lastError, 'baseTerm')
             _locals['f'] = _G_apply_383
             def _G_or_384():
+                self._trace("'('", (2510, 2513), self.input.position)
                 _G_exactly_385, lastError = self.exactly('(')
                 self.considerError(lastError, None)
+                self._trace(' argList', (2513, 2521), self.input.position)
                 _G_apply_386, lastError = self._apply(self.rule_argList, "argList", [])
                 self.considerError(lastError, None)
                 _locals['a'] = _G_apply_386
+                self._trace(' ws', (2523, 2526), self.input.position)
                 _G_apply_387, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
+                self._trace(" ')'", (2526, 2530), self.input.position)
                 _G_exactly_388, lastError = self.exactly(')')
                 self.considerError(lastError, None)
                 _G_python_389, lastError = eval('makeTerm(f, a)', self.globals, _locals), None
@@ -986,6 +1132,7 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_arg(self):
             _locals = {'self': self}
             self.locals['arg'] = _locals
+            self._trace(' term', (2600, 2605), self.input.position)
             _G_apply_393, lastError = self._apply(self.rule_term, "term", [])
             self.considerError(lastError, 'arg')
             return (_G_apply_393, self.currentError)
@@ -995,23 +1142,29 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['argList'] = _locals
             def _G_or_394():
+                self._trace('arg', (2619, 2622), self.input.position)
                 _G_apply_395, lastError = self._apply(self.rule_arg, "arg", [])
                 self.considerError(lastError, None)
                 _locals['t'] = _G_apply_395
                 def _G_many_396():
+                    self._trace('ws', (2626, 2628), self.input.position)
                     _G_apply_397, lastError = self._apply(self.rule_ws, "ws", [])
                     self.considerError(lastError, None)
+                    self._trace(" ','", (2628, 2632), self.input.position)
                     _G_exactly_398, lastError = self.exactly(',')
                     self.considerError(lastError, None)
+                    self._trace(' arg', (2632, 2636), self.input.position)
                     _G_apply_399, lastError = self._apply(self.rule_arg, "arg", [])
                     self.considerError(lastError, None)
                     return (_G_apply_399, self.currentError)
                 _G_many_400, lastError = self.many(_G_many_396)
                 self.considerError(lastError, None)
                 _locals['ts'] = _G_many_400
+                self._trace(' ws', (2641, 2644), self.input.position)
                 _G_apply_401, lastError = self._apply(self.rule_ws, "ws", [])
                 self.considerError(lastError, None)
                 def _G_optional_402():
+                    self._trace(" ','", (2644, 2648), self.input.position)
                     _G_exactly_403, lastError = self.exactly(',')
                     self.considerError(lastError, None)
                     return (_G_exactly_403, self.currentError)
@@ -1023,7 +1176,7 @@ def createParserClass(GrammarBase, ruleGlobals):
                 self.considerError(lastError, None)
                 return (_G_python_406, self.currentError)
             def _G_or_407():
-                _G_python_408, lastError = [], None
+                _G_python_408, lastError = ([]), None
                 self.considerError(lastError, None)
                 return (_G_python_408, self.currentError)
             _G_or_409, lastError = self._or([_G_or_394, _G_or_407])
@@ -1034,15 +1187,20 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_tupleTerm(self):
             _locals = {'self': self}
             self.locals['tupleTerm'] = _locals
+            self._trace(' ws', (2699, 2702), self.input.position)
             _G_apply_410, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'tupleTerm')
+            self._trace(" '['", (2702, 2706), self.input.position)
             _G_exactly_411, lastError = self.exactly('[')
             self.considerError(lastError, 'tupleTerm')
+            self._trace(' argList', (2706, 2714), self.input.position)
             _G_apply_412, lastError = self._apply(self.rule_argList, "argList", [])
             self.considerError(lastError, 'tupleTerm')
             _locals['a'] = _G_apply_412
+            self._trace(' ws', (2716, 2719), self.input.position)
             _G_apply_413, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'tupleTerm')
+            self._trace(" ']'", (2719, 2723), self.input.position)
             _G_exactly_414, lastError = self.exactly(']')
             self.considerError(lastError, 'tupleTerm')
             _G_python_415, lastError = eval('Tuple(a)', self.globals, _locals), None
@@ -1053,15 +1211,20 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_bagTerm(self):
             _locals = {'self': self}
             self.locals['bagTerm'] = _locals
+            self._trace(' ws', (2746, 2749), self.input.position)
             _G_apply_416, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'bagTerm')
+            self._trace(" '{'", (2749, 2753), self.input.position)
             _G_exactly_417, lastError = self.exactly('{')
             self.considerError(lastError, 'bagTerm')
+            self._trace(' argList', (2753, 2761), self.input.position)
             _G_apply_418, lastError = self._apply(self.rule_argList, "argList", [])
             self.considerError(lastError, 'bagTerm')
             _locals['a'] = _G_apply_418
+            self._trace(' ws', (2763, 2766), self.input.position)
             _G_apply_419, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'bagTerm')
+            self._trace(" '}'", (2766, 2770), self.input.position)
             _G_exactly_420, lastError = self.exactly('}')
             self.considerError(lastError, 'bagTerm')
             _G_python_421, lastError = eval('Bag(a)', self.globals, _locals), None
@@ -1072,9 +1235,11 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_labelledBagTerm(self):
             _locals = {'self': self}
             self.locals['labelledBagTerm'] = _locals
+            self._trace(' functor', (2799, 2807), self.input.position)
             _G_apply_422, lastError = self._apply(self.rule_functor, "functor", [])
             self.considerError(lastError, 'labelledBagTerm')
             _locals['f'] = _G_apply_422
+            self._trace(' bagTerm', (2809, 2817), self.input.position)
             _G_apply_423, lastError = self._apply(self.rule_bagTerm, "bagTerm", [])
             self.considerError(lastError, 'labelledBagTerm')
             _locals['b'] = _G_apply_423
@@ -1087,18 +1252,22 @@ def createParserClass(GrammarBase, ruleGlobals):
             _locals = {'self': self}
             self.locals['extraTerm'] = _locals
             def _G_or_425():
+                self._trace(' tupleTerm', (2853, 2863), self.input.position)
                 _G_apply_426, lastError = self._apply(self.rule_tupleTerm, "tupleTerm", [])
                 self.considerError(lastError, None)
                 return (_G_apply_426, self.currentError)
             def _G_or_427():
+                self._trace(' labelledBagTerm', (2865, 2881), self.input.position)
                 _G_apply_428, lastError = self._apply(self.rule_labelledBagTerm, "labelledBagTerm", [])
                 self.considerError(lastError, None)
                 return (_G_apply_428, self.currentError)
             def _G_or_429():
+                self._trace(' bagTerm', (2884, 2892), self.input.position)
                 _G_apply_430, lastError = self._apply(self.rule_bagTerm, "bagTerm", [])
                 self.considerError(lastError, None)
                 return (_G_apply_430, self.currentError)
             def _G_or_431():
+                self._trace(' baseTerm', (2894, 2903), self.input.position)
                 _G_apply_432, lastError = self._apply(self.rule_baseTerm, "baseTerm", [])
                 self.considerError(lastError, None)
                 return (_G_apply_432, self.currentError)
@@ -1110,13 +1279,17 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_attrTerm(self):
             _locals = {'self': self}
             self.locals['attrTerm'] = _locals
+            self._trace(' extraTerm', (2915, 2925), self.input.position)
             _G_apply_434, lastError = self._apply(self.rule_extraTerm, "extraTerm", [])
             self.considerError(lastError, 'attrTerm')
             _locals['k'] = _G_apply_434
+            self._trace(' ws', (2927, 2930), self.input.position)
             _G_apply_435, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'attrTerm')
+            self._trace(" ':'", (2930, 2934), self.input.position)
             _G_exactly_436, lastError = self.exactly(':')
             self.considerError(lastError, 'attrTerm')
+            self._trace(' extraTerm', (2934, 2944), self.input.position)
             _G_apply_437, lastError = self._apply(self.rule_extraTerm, "extraTerm", [])
             self.considerError(lastError, 'attrTerm')
             _locals['v'] = _G_apply_437
@@ -1128,13 +1301,16 @@ def createParserClass(GrammarBase, ruleGlobals):
         def rule_term(self):
             _locals = {'self': self}
             self.locals['term'] = _locals
+            self._trace(' ws', (2968, 2971), self.input.position)
             _G_apply_439, lastError = self._apply(self.rule_ws, "ws", [])
             self.considerError(lastError, 'term')
             def _G_or_440():
+                self._trace('attrTerm', (2973, 2981), self.input.position)
                 _G_apply_441, lastError = self._apply(self.rule_attrTerm, "attrTerm", [])
                 self.considerError(lastError, None)
                 return (_G_apply_441, self.currentError)
             def _G_or_442():
+                self._trace(' extraTerm', (2983, 2993), self.input.position)
                 _G_apply_443, lastError = self._apply(self.rule_extraTerm, "extraTerm", [])
                 self.considerError(lastError, None)
                 return (_G_apply_443, self.currentError)


### PR DESCRIPTION
Example: rule = (-> (1, 2, 3)):(a, b, c)

In order to remove the redudant outer parentheses, I modified the compilePythonExpr inside builder.py.
Now it could support:
rule = (-> 1, 2, 3):(a, b, c)

Also some part related to incremental parsing are modified.
