### PR TITLE
add buffer ability to trampolined parser

### DIFF
--- a/ometa/tube.py
+++ b/ometa/tube.py
@@ -42,6 +42,8 @@ class TrampolinedParser:
         """
         if self._buffer:
             data = self._buffer + data
+            # Note here to reset the buffer
+            self._buffer = b''
         while data and not getattr(self.receiver, "paused", False):
             status = self._interp.receive(data)
             if status is _feed_me:


### PR DESCRIPTION
The pause and produce status may change in the mean while of parsing. So we have to control whether or not to pause the parsing inside trampolinedParser.receive
A more concrete example can be seen here:
https://github.com/twisted/parsley-protocols/blob/basic/parseproto/test/test_basic.py#L253
