### PR TITLE
remove string casting from error formatting

### DIFF
--- a/ometa/runtime.py
+++ b/ometa/runtime.py
@@ -75,7 +75,7 @@ class ParseError(Exception):
         parsing failure.
         """
         #de-twineifying
-        lines = str(self.input).split('\n')
+        lines = self.input.split('\n')
         counter = 0
         lineNo = 1
         columnNo = 0


### PR DESCRIPTION
Error formatting fails on unicode characters that can't be encoded in ascii
