### PR TITLE
Fix deprecated assertions

### DIFF
--- a/ometa/test/test_builder.py
+++ b/ometa/test/test_builder.py
@@ -325,7 +325,7 @@ class PythonWriterTests(unittest.TestCase):
         x = t.Rule("foo", t.List(
                 t.Exactly("x")))
         g = t.Grammar("TestGrammar", True, [x])
-        self.assert_("\n        tree = True\n" in writePython(g, ""))
+        self.assertIn("\n        tree = True\n", writePython(g, ""))
 
 
     def test_rule(self):

--- a/ometa/test/test_protocol.py
+++ b/ometa/test/test_protocol.py
@@ -90,7 +90,7 @@ class ParserProtocolTestCase(unittest.TestCase):
     def test_connectionEstablishes(self):
         """prepareParsing is called on the receiver after connection establishment."""
         self.protocol.makeConnection(None)
-        self.assert_(self.protocol.receiver.connected)
+        self.assertTrue(self.protocol.receiver.connected)
 
     def test_basicParsing(self):
         """Rules can be parsed multiple times for the same effect."""
@@ -161,10 +161,10 @@ class ParserProtocolTestCase(unittest.TestCase):
         transport = FakeTransport()
         self.protocol.makeConnection(transport)
         self.protocol.dataReceived('b')
-        self.failIfEqual(self.protocol.receiver.lossReason, None)
+        self.assertIsNotNone(self.protocol.receiver.lossReason)
         self.assertTrue(
             isinstance(self.protocol.receiver.lossReason.value, ParseError))
-        self.assert_(transport.aborted)
+        self.assertTrue(transport.aborted)
 
     def test_exceptionsRaisedFromReceiver(self):
         """
@@ -174,10 +174,10 @@ class ParserProtocolTestCase(unittest.TestCase):
         transport = FakeTransport()
         self.protocol.makeConnection(transport)
         self.protocol.dataReceived('e')
-        self.failIfEqual(self.protocol.receiver.lossReason, None)
+        self.assertIsNotNone(self.protocol.receiver.lossReason)
         self.assertTrue(
             isinstance(self.protocol.receiver.lossReason.value, SomeException))
-        self.assert_(transport.aborted)
+        self.assertTrue(transport.aborted)
 
     def test_dataIgnoredAfterDisconnection(self):
         """After connectionLost is called, all incoming data is ignored."""
@@ -187,4 +187,4 @@ class ParserProtocolTestCase(unittest.TestCase):
         self.protocol.connectionLost(reason)
         self.protocol.dataReceived('d')
         self.assertEqual(self.protocol.receiver.lossReason, reason)
-        self.assert_(not transport.aborted)
+        self.assertFalse(transport.aborted)

--- a/ometa/test/test_pymeta.py
+++ b/ometa/test/test_pymeta.py
@@ -1138,8 +1138,8 @@ class MakeGrammarTest(TestCase):
         """
         e = self.assertRaises(ParseError, OMeta.makeGrammar, grammar,
                               "Foo")
-        self.assertEquals(e.position, 57)
-        self.assertEquals(e.error, [("message", "end of input")])
+        self.assertEqual(e.position, 57)
+        self.assertEqual(e.error, [("message", "end of input")])
 
 
     def test_subclassing(self):

--- a/ometa/test/test_runtime.py
+++ b/ometa/test/test_runtime.py
@@ -54,8 +54,8 @@ class RuntimeTests(TestCase):
         data = "foo"
         o = OMetaBase(data)
         exc = self.assertRaises(ParseError, o.rule_exactly, "g")
-        self.assertEquals(exc.args[1], expected(None, "g"))
-        self.assertEquals(exc.args[0], 0)
+        self.assertEqual(exc.args[1], expected(None, "g"))
+        self.assertEqual(exc.args[0], 0)
 
 
 


### PR DESCRIPTION
Python 3.1 and Python 3.2 deprecated a large amount of assertions, and have finally been removed in Python 3.12. Move to the "new" function names.

Fixes #80